### PR TITLE
Feat: Centralize Auth via Middleware for Web & API

### DIFF
--- a/app/Controllers/Api/BaseApiController.php
+++ b/app/Controllers/Api/BaseApiController.php
@@ -34,23 +34,6 @@ abstract class BaseApiController extends BaseController
     }
 
     /**
-     * Require authentication for API endpoints
-     * Override parent method to use API-specific error responses
-     */
-    protected function requireAuth(string $permission = null): void
-    {
-        if (!$this->authService->isLoggedIn()) {
-            $this->apiError('Authentication required', 'UNAUTHORIZED', 401);
-        }
-
-        if ($permission !== null) {
-            if (!$this->authService->check($permission)) {
-                $this->apiError('Access denied. Insufficient permissions.', 'FORBIDDEN', 403);
-            }
-        }
-    }
-
-    /**
      * Send a successful API response
      */
     protected function apiSuccess($data = null, string $message = 'Success'): void

--- a/app/Controllers/Api/EmployeeApiController.php
+++ b/app/Controllers/Api/EmployeeApiController.php
@@ -24,7 +24,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth('employee_admin');
         try {
             $filters = [
                 'department_id' => $this->request->input('department_id'),
@@ -44,7 +43,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function getInitialData(): void
     {
-        $this->requireAuth('employee_admin');
         try {
             $departments = DepartmentRepository::getAll();
             $positions = PositionRepository::getAll();
@@ -63,7 +61,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function show(int $id): void
     {
-        $this->requireAuth('employee_admin');
         try {
             $employee = $this->employeeService->getEmployee($id);
             if ($employee) {
@@ -81,7 +78,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function store(): void
     {
-        $this->requireAuth('employee_admin');
         try {
             $input = $this->getJsonInput();
             if (empty($input)) {
@@ -102,7 +98,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function update(int $id): void
     {
-        $this->requireAuth('employee_admin');
         try {
             $input = $this->getJsonInput();
             if (empty($input)) {
@@ -123,7 +118,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function destroy(int $id): void
     {
-        $this->requireAuth('employee_admin');
         try {
             if ($this->employeeService->deleteEmployee($id)) {
                 $this->apiSuccess(null, '직원 정보가 삭제되었습니다.');
@@ -142,7 +136,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function getChangeHistory(int $id): void
     {
-        $this->requireAuth('employee_admin');
         try {
             $history = EmployeeChangeLogRepository::findByEmployeeId($id);
             $this->apiSuccess($history);
@@ -156,7 +149,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function unlinked(): void
     {
-        $this->requireAuth('user_admin');
         try {
             $unlinkedEmployees = $this->employeeService->getUnlinkedEmployees();
             $this->apiSuccess($unlinkedEmployees);
@@ -170,8 +162,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function approveUpdate(int $id): void
     {
-        $this->requireAuth('employee_admin');
-
         if (empty($id)) {
             $this->apiBadRequest('Employee ID is required.');
             return;
@@ -193,8 +183,6 @@ class EmployeeApiController extends BaseApiController
      */
     public function rejectUpdate(int $id): void
     {
-        $this->requireAuth('employee_admin');
-
         if (empty($id)) {
             $this->apiBadRequest('Employee ID is required.');
             return;

--- a/app/Controllers/Api/HolidayApiController.php
+++ b/app/Controllers/Api/HolidayApiController.php
@@ -20,7 +20,6 @@ class HolidayApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth('holiday_admin');
 
         try {
             $holidays = $this->holidayService->getAllHolidays();
@@ -40,7 +39,6 @@ class HolidayApiController extends BaseApiController
      */
     public function show(int $id): void
     {
-        $this->requireAuth('holiday_admin');
 
         try {
             $holiday = $this->holidayService->getHoliday($id);
@@ -61,7 +59,6 @@ class HolidayApiController extends BaseApiController
      */
     public function store(): void
     {
-        $this->requireAuth('holiday_admin');
 
         try {
             $data = $this->getJsonInput();
@@ -96,7 +93,6 @@ class HolidayApiController extends BaseApiController
      */
     public function update(int $id): void
     {
-        $this->requireAuth('holiday_admin');
 
         try {
             $data = $this->getJsonInput();
@@ -131,7 +127,6 @@ class HolidayApiController extends BaseApiController
      */
     public function destroy(int $id): void
     {
-        $this->requireAuth('holiday_admin');
 
         try {
             $this->holidayService->deleteHoliday($id);

--- a/app/Controllers/Api/LeaveAdminApiController.php
+++ b/app/Controllers/Api/LeaveAdminApiController.php
@@ -22,7 +22,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function listRequests(): void
     {
-        $this->requireAuth('leave_admin');
         $status = $this->request->input('status', 'pending');
 
         try {
@@ -43,7 +42,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function approveRequest(int $id): void
     {
-        $this->requireAuth('leave_admin');
         $adminId = $this->user()['id'];
 
         try {
@@ -64,7 +62,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function rejectRequest(int $id): void
     {
-        $this->requireAuth('leave_admin');
         $adminId = $this->user()['id'];
         $reason = $this->request->input('reason');
 
@@ -91,7 +88,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function approveCancellation(int $id): void
     {
-        $this->requireAuth('leave_admin');
         $adminId = $this->user()['id'];
 
         try {
@@ -112,7 +108,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function rejectCancellation(int $id): void
     {
-        $this->requireAuth('leave_admin');
         $adminId = $this->user()['id'];
         $reason = $this->request->input('reason');
         
@@ -139,7 +134,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function listEntitlements(): void
     {
-        $this->requireAuth('leave_admin');
         $filters = [
             'year' => $this->request->input('year', date('Y')),
             'department_id' => $this->request->input('department_id')
@@ -159,7 +153,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function grantForAll(): void
     {
-        $this->requireAuth('leave_admin');
         $year = (int)$this->request->input('year', date('Y'));
 
         try {
@@ -180,7 +173,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function getHistory(int $employeeId): void
     {
-        $this->requireAuth('leave_admin');
         $year = (int)$this->request->input('year', date('Y'));
 
         try {
@@ -202,7 +194,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function manualAdjustment(): void
     {
-        $this->requireAuth('leave_admin');
         $adminId = $this->user()['id'];
         
         $data = $this->getJsonInput();
@@ -233,7 +224,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function calculateLeaves(): void
     {
-        $this->requireAuth('leave_admin');
         
         $data = $this->getJsonInput();
         $year = (int)($data['year'] ?? date('Y'));
@@ -268,7 +258,6 @@ class LeaveAdminApiController extends BaseApiController
      */
     public function saveEntitlements(): void
     {
-        $this->requireAuth('leave_admin');
         
         $data = $this->getJsonInput();
         $employees_data = $data['employees'] ?? [];

--- a/app/Controllers/Api/LeaveApiController.php
+++ b/app/Controllers/Api/LeaveApiController.php
@@ -22,7 +22,6 @@ class LeaveApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth('leave_view');
         
         $employeeId = $this->user()['employee_id'] ?? null;
         if (!$employeeId) {
@@ -51,7 +50,6 @@ class LeaveApiController extends BaseApiController
      */
     public function store(): void
     {
-        $this->requireAuth('leave_request');
         
         $employeeId = $this->user()['employee_id'] ?? null;
         if (!$employeeId) {
@@ -84,7 +82,6 @@ class LeaveApiController extends BaseApiController
      */
     public function cancel(int $id): void
     {
-        $this->requireAuth('leave_request');
         
         $employeeId = $this->user()['employee_id'] ?? null;
         if (!$employeeId) {
@@ -114,7 +111,6 @@ class LeaveApiController extends BaseApiController
      */
     public function calculateDays(): void
     {
-        $this->requireAuth('leave_request');
         
         $employeeId = $this->user()['employee_id'] ?? null;
         if (!$employeeId) {

--- a/app/Controllers/Api/LitteringAdminApiController.php
+++ b/app/Controllers/Api/LitteringAdminApiController.php
@@ -21,7 +21,6 @@ class LitteringAdminApiController extends BaseApiController
      */
     public function listReports(): void
     {
-        $this->requireAuth('littering_manage');
         $status = $this->request->input('status', 'pending'); // 'pending', 'deleted'
 
         try {
@@ -45,7 +44,6 @@ class LitteringAdminApiController extends BaseApiController
      */
     public function confirm(int $id): void
     {
-        $this->requireAuth('littering_manage');
         $adminId = $this->user()['id'];
         
         try {
@@ -65,7 +63,6 @@ class LitteringAdminApiController extends BaseApiController
      */
     public function destroy(int $id): void
     {
-        $this->requireAuth('littering_manage');
         $adminId = $this->user()['id'];
 
         try {
@@ -85,7 +82,6 @@ class LitteringAdminApiController extends BaseApiController
      */
     public function restore(int $id): void
     {
-        $this->requireAuth('littering_admin');
         
         try {
             $data = ['id' => $id];
@@ -102,7 +98,6 @@ class LitteringAdminApiController extends BaseApiController
      */
     public function permanentlyDelete(int $id): void
     {
-        $this->requireAuth('littering_admin'); // Or a higher permission if needed
 
         try {
             $data = ['id' => $id];

--- a/app/Controllers/Api/LitteringApiController.php
+++ b/app/Controllers/Api/LitteringApiController.php
@@ -21,7 +21,6 @@ class LitteringApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth('littering_view');
         $status = $this->request->input('status', 'active'); // 'active', 'processed'
 
         try {
@@ -45,7 +44,6 @@ class LitteringApiController extends BaseApiController
      */
     public function store(): void
     {
-        $this->requireAuth('littering_process');
 
         $user = $this->user();
         if (!$user) {
@@ -76,7 +74,6 @@ class LitteringApiController extends BaseApiController
      */
     public function process(int $id): void
     {
-        $this->requireAuth('littering_process');
         
         try {
             $data = $this->request->all(); // POST data is appropriate here

--- a/app/Controllers/Api/LogApiController.php
+++ b/app/Controllers/Api/LogApiController.php
@@ -13,7 +13,6 @@ class LogApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth('log_admin');
         
         try {
             $filters = [
@@ -36,7 +35,6 @@ class LogApiController extends BaseApiController
      */
     public function destroy(): void
     {
-        $this->requireAuth('log_admin');
         
         try {
             LogRepository::truncate();

--- a/app/Controllers/Api/MenuApiController.php
+++ b/app/Controllers/Api/MenuApiController.php
@@ -17,7 +17,6 @@ class MenuApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth('menu_admin');
         
         try {
             $sql = "SELECT * FROM sys_menus ORDER BY parent_id, display_order";
@@ -33,7 +32,6 @@ class MenuApiController extends BaseApiController
      */
     public function show(int $id): void
     {
-        $this->requireAuth('menu_admin');
 
         try {
             if (empty($id)) {
@@ -59,7 +57,6 @@ class MenuApiController extends BaseApiController
      */
     public function store(): void
     {
-        $this->requireAuth('menu_admin');
         
         try {
             $data = $this->getJsonInput();
@@ -96,7 +93,6 @@ class MenuApiController extends BaseApiController
      */
     public function update(int $id): void
     {
-        $this->requireAuth('menu_admin');
 
         try {
             if (empty($id)) {
@@ -139,7 +135,6 @@ class MenuApiController extends BaseApiController
      */
     public function updateOrder(): void
     {
-        $this->requireAuth('menu_admin');
 
         try {
             $data = $this->getJsonInput();
@@ -179,7 +174,6 @@ class MenuApiController extends BaseApiController
      */
     public function destroy(int $id): void
     {
-        $this->requireAuth('menu_admin');
         
         try {
             if (!$id) {

--- a/app/Controllers/Api/OrganizationApiController.php
+++ b/app/Controllers/Api/OrganizationApiController.php
@@ -37,7 +37,6 @@ class OrganizationApiController extends BaseApiController
     public function store(): void
     {
         try {
-            $this->requireAuth('organization_admin');
             $input = $this->getJsonInput();
             $type = $input['type'] ?? '';
             $name = trim($input['name'] ?? '');
@@ -64,7 +63,6 @@ class OrganizationApiController extends BaseApiController
     public function update(int $id): void
     {
         try {
-            $this->requireAuth('organization_admin');
             $input = $this->getJsonInput();
             $type = $input['type'] ?? '';
             $name = trim($input['name'] ?? '');
@@ -91,7 +89,6 @@ class OrganizationApiController extends BaseApiController
     public function destroy(int $id): void
     {
         try {
-            $this->requireAuth('organization_admin');
             $input = $this->getJsonInput();
             $type = $input['type'] ?? '';
 

--- a/app/Controllers/Api/ProfileApiController.php
+++ b/app/Controllers/Api/ProfileApiController.php
@@ -21,7 +21,6 @@ class ProfileApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth();
         
         try {
             $userId = $this->user()['id'];
@@ -38,7 +37,6 @@ class ProfileApiController extends BaseApiController
      */
     public function update(): void
     {
-        $this->requireAuth();
         
         try {
             $userId = $this->user()['id'];

--- a/app/Controllers/Api/RoleApiController.php
+++ b/app/Controllers/Api/RoleApiController.php
@@ -18,7 +18,6 @@ class RoleApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth('role_admin');
         try {
             $roles = RoleRepository::getAllRolesWithUserCount();
             $this->apiSuccess($roles);
@@ -33,7 +32,6 @@ class RoleApiController extends BaseApiController
      */
     public function show(int $id): void
     {
-        $this->requireAuth('role_admin');
         try {
             $role = RoleRepository::findById($id);
             if (!$role) {
@@ -61,7 +59,6 @@ class RoleApiController extends BaseApiController
      */
     public function store(): void
     {
-        $this->requireAuth('role_admin');
         try {
             $input = $this->getJsonInput();
             $name = trim($input['name'] ?? '');
@@ -85,7 +82,6 @@ class RoleApiController extends BaseApiController
      */
     public function update(int $id): void
     {
-        $this->requireAuth('role_admin');
         try {
             $input = $this->getJsonInput();
             $name = trim($input['name'] ?? '');
@@ -109,7 +105,6 @@ class RoleApiController extends BaseApiController
      */
     public function destroy(int $id): void
     {
-        $this->requireAuth('role_admin');
         try {
             if (RoleRepository::delete($id)) {
                 $this->apiSuccess(null, '역할이 삭제되었습니다.');
@@ -127,7 +122,6 @@ class RoleApiController extends BaseApiController
      */
     public function updatePermissions(int $id): void
     {
-        $this->requireAuth('role_admin');
         try {
             $input = $this->getJsonInput();
             $permissionIds = $input['permissions'] ?? [];

--- a/app/Controllers/Api/UserApiController.php
+++ b/app/Controllers/Api/UserApiController.php
@@ -22,7 +22,6 @@ class UserApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth('user_admin');
         try {
             $filters = [
                 'status' => $this->request->input('status'),
@@ -44,7 +43,6 @@ class UserApiController extends BaseApiController
      */
     public function show(int $id): void
     {
-        $this->requireAuth('user_admin');
         try {
             $user = $this->userService->getUser($id);
             if ($user) {
@@ -64,7 +62,6 @@ class UserApiController extends BaseApiController
      */
     public function update(int $id): void
     {
-        $this->requireAuth('user_admin');
         try {
             $input = $this->getJsonInput();
             if ($this->userService->updateUser($id, $input)) {
@@ -89,7 +86,6 @@ class UserApiController extends BaseApiController
      */
     public function linkEmployee(int $id): void
     {
-        $this->requireAuth('user_admin');
         try {
             $input = $this->getJsonInput();
             $employeeId = (int)($input['employee_id'] ?? 0);
@@ -114,7 +110,6 @@ class UserApiController extends BaseApiController
      */
     public function unlinkEmployee(int $id): void
     {
-        $this->requireAuth('user_admin');
         try {
             if ($this->userService->unlinkEmployee($id)) {
                 $this->apiSuccess(null, '직원 연결이 해제되었습니다.');

--- a/app/Controllers/Api/WasteCollectionApiController.php
+++ b/app/Controllers/Api/WasteCollectionApiController.php
@@ -21,7 +21,6 @@ class WasteCollectionApiController extends BaseApiController
      */
     public function index(): void
     {
-        $this->requireAuth();
         try {
             $data = $this->wasteCollectionService->getCollections();
             $this->apiSuccess($data, '수거 목록 조회 성공');
@@ -36,7 +35,6 @@ class WasteCollectionApiController extends BaseApiController
      */
     public function store(): void
     {
-        $this->requireAuth();
         $user = $this->user();
         try {
             $result = $this->wasteCollectionService->registerCollection($_POST, $_FILES, $user['id'], $user['employee_id'] ?? null);
@@ -52,7 +50,6 @@ class WasteCollectionApiController extends BaseApiController
      */
     public function getAdminCollections(): void
     {
-        $this->requireAuth('waste_admin');
         try {
             $collections = $this->wasteCollectionService->getAdminCollections($this->request->all());
             $this->apiSuccess($collections);
@@ -67,7 +64,6 @@ class WasteCollectionApiController extends BaseApiController
      */
     public function processCollection(int $id): void
     {
-        $this->requireAuth('waste_admin');
         try {
             $result = $this->wasteCollectionService->processCollectionById($id);
             $this->apiSuccess($result, '선택한 항목이 처리되었습니다.');
@@ -82,7 +78,6 @@ class WasteCollectionApiController extends BaseApiController
      */
     public function updateItems(int $id): void
     {
-        $this->requireAuth('waste_admin');
         try {
             $items = $this->request->input('items', '[]');
             $result = $this->wasteCollectionService->updateCollectionItems($id, $items);
@@ -98,7 +93,6 @@ class WasteCollectionApiController extends BaseApiController
      */
     public function updateMemo(int $id): void
     {
-        $this->requireAuth('waste_admin');
         try {
             $memo = $this->request->input('memo', '');
             $result = $this->wasteCollectionService->updateAdminMemo($id, $memo);
@@ -114,7 +108,6 @@ class WasteCollectionApiController extends BaseApiController
      */
     public function parseHtmlFile(): void
     {
-        $this->requireAuth('waste_admin');
         if (empty($_FILES['htmlFile'])) {
             $this->apiError('HTML 파일이 없습니다.', 'INVALID_INPUT', 400);
             return;
@@ -133,7 +126,6 @@ class WasteCollectionApiController extends BaseApiController
      */
     public function batchRegister(): void
     {
-        $this->requireAuth('waste_admin');
         $userId = $this->user()['id'];
         $collections = $this->request->input('collections', []);
         if (empty($collections)) {
@@ -154,7 +146,6 @@ class WasteCollectionApiController extends BaseApiController
      */
     public function clearOnlineSubmissions(): void
     {
-        $this->requireAuth('waste_admin');
         try {
             $result = $this->wasteCollectionService->clearOnlineSubmissions();
             $this->apiSuccess($result, '모든 인터넷 배출 데이터가 삭제되었습니다.');

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,102 +16,101 @@ use App\Controllers\Api\LogApiController;
 use App\Controllers\Api\WasteCollectionApiController;
 
 Router::group('/api', function() {
-    // Employee API routes (Refactored to be RESTful)
-    Router::get('/employees', [EmployeeApiController::class, 'index'])->name('api.employees.index');
-    Router::post('/employees', [EmployeeApiController::class, 'store'])->name('api.employees.store');
-    Router::get('/employees/initial-data', [EmployeeApiController::class, 'getInitialData'])->name('api.employees.initial-data');
-    Router::get('/employees/unlinked', [EmployeeApiController::class, 'unlinked'])->name('api.employees.unlinked');
-    Router::get('/employees/{id}', [EmployeeApiController::class, 'show'])->name('api.employees.show');
-    Router::put('/employees/{id}', [EmployeeApiController::class, 'update'])->name('api.employees.update');
-    Router::delete('/employees/{id}', [EmployeeApiController::class, 'destroy'])->name('api.employees.destroy');
-    Router::get('/employees/{id}/history', [EmployeeApiController::class, 'getChangeHistory'])->name('api.employees.history');
-    Router::post('/employees/{id}/approve-update', [EmployeeApiController::class, 'approveUpdate'])->name('api.employees.approve-update');
-    Router::post('/employees/{id}/reject-update', [EmployeeApiController::class, 'rejectUpdate'])->name('api.employees.reject-update');
+    // Employee API routes
+    Router::get('/employees', [EmployeeApiController::class, 'index'])->name('api.employees.index')->middleware('auth')->middleware('permission', 'employee_admin');
+    Router::post('/employees', [EmployeeApiController::class, 'store'])->name('api.employees.store')->middleware('auth')->middleware('permission', 'employee_admin');
+    Router::get('/employees/initial-data', [EmployeeApiController::class, 'getInitialData'])->name('api.employees.initial-data')->middleware('auth')->middleware('permission', 'employee_admin');
+    Router::get('/employees/unlinked', [EmployeeApiController::class, 'unlinked'])->name('api.employees.unlinked')->middleware('auth')->middleware('permission', 'user_admin');
+    Router::get('/employees/{id}', [EmployeeApiController::class, 'show'])->name('api.employees.show')->middleware('auth')->middleware('permission', 'employee_admin');
+    Router::put('/employees/{id}', [EmployeeApiController::class, 'update'])->name('api.employees.update')->middleware('auth')->middleware('permission', 'employee_admin');
+    Router::delete('/employees/{id}', [EmployeeApiController::class, 'destroy'])->name('api.employees.destroy')->middleware('auth')->middleware('permission', 'employee_admin');
+    Router::get('/employees/{id}/history', [EmployeeApiController::class, 'getChangeHistory'])->name('api.employees.history')->middleware('auth')->middleware('permission', 'employee_admin');
+    Router::post('/employees/{id}/approve-update', [EmployeeApiController::class, 'approveUpdate'])->name('api.employees.approve-update')->middleware('auth')->middleware('permission', 'employee_admin');
+    Router::post('/employees/{id}/reject-update', [EmployeeApiController::class, 'rejectUpdate'])->name('api.employees.reject-update')->middleware('auth')->middleware('permission', 'employee_admin');
 
     // Holiday API routes
-    Router::get('/holidays', [HolidayApiController::class, 'index'])->name('api.holidays.index');
-    Router::post('/holidays', [HolidayApiController::class, 'store'])->name('api.holidays.store');
-    Router::get('/holidays/{id}', [HolidayApiController::class, 'show'])->name('api.holidays.show');
-    Router::put('/holidays/{id}', [HolidayApiController::class, 'update'])->name('api.holidays.update');
-    Router::delete('/holidays/{id}', [HolidayApiController::class, 'destroy'])->name('api.holidays.destroy');
+    Router::get('/holidays', [HolidayApiController::class, 'index'])->name('api.holidays.index')->middleware('auth')->middleware('permission', 'holiday_admin');
+    Router::post('/holidays', [HolidayApiController::class, 'store'])->name('api.holidays.store')->middleware('auth')->middleware('permission', 'holiday_admin');
+    Router::get('/holidays/{id}', [HolidayApiController::class, 'show'])->name('api.holidays.show')->middleware('auth')->middleware('permission', 'holiday_admin');
+    Router::put('/holidays/{id}', [HolidayApiController::class, 'update'])->name('api.holidays.update')->middleware('auth')->middleware('permission', 'holiday_admin');
+    Router::delete('/holidays/{id}', [HolidayApiController::class, 'destroy'])->name('api.holidays.destroy')->middleware('auth')->middleware('permission', 'holiday_admin');
 
     // Leave API routes (User)
-    Router::get('/leaves', [LeaveApiController::class, 'index'])->name('api.leaves.index');
-    Router::post('/leaves', [LeaveApiController::class, 'store'])->name('api.leaves.store');
-    Router::post('/leaves/{id}/cancel', [LeaveApiController::class, 'cancel'])->name('api.leaves.cancel');
-    Router::post('/leaves/calculate-days', [LeaveApiController::class, 'calculateDays'])->name('api.leaves.calculate-days');
+    Router::get('/leaves', [LeaveApiController::class, 'index'])->name('api.leaves.index')->middleware('auth')->middleware('permission', 'leave_view');
+    Router::post('/leaves', [LeaveApiController::class, 'store'])->name('api.leaves.store')->middleware('auth')->middleware('permission', 'leave_request');
+    Router::post('/leaves/{id}/cancel', [LeaveApiController::class, 'cancel'])->name('api.leaves.cancel')->middleware('auth')->middleware('permission', 'leave_request');
+    Router::post('/leaves/calculate-days', [LeaveApiController::class, 'calculateDays'])->name('api.leaves.calculate-days')->middleware('auth')->middleware('permission', 'leave_request');
 
     // Leave Admin API routes
-    Router::get('/leaves_admin/requests', [LeaveAdminApiController::class, 'listRequests'])->name('api.leaves_admin.requests');
-    Router::post('/leaves_admin/requests/{id}/approve', [LeaveAdminApiController::class, 'approveRequest'])->name('api.leaves_admin.approve');
-    Router::post('/leaves_admin/requests/{id}/reject', [LeaveAdminApiController::class, 'rejectRequest'])->name('api.leaves_admin.reject');
-    Router::post('/leaves_admin/cancellations/{id}/approve', [LeaveAdminApiController::class, 'approveCancellation'])->name('api.leaves_admin.cancellations.approve');
-    Router::post('/leaves_admin/cancellations/{id}/reject', [LeaveAdminApiController::class, 'rejectCancellation'])->name('api.leaves_admin.cancellations.reject');
-    Router::get('/leaves_admin/entitlements', [LeaveAdminApiController::class, 'listEntitlements'])->name('api.leaves_admin.entitlements');
-    Router::post('/leaves_admin/grant-all', [LeaveAdminApiController::class, 'grantForAll'])->name('api.leaves_admin.grant-all');
-    Router::get('/leaves_admin/history/{employeeId}', [LeaveAdminApiController::class, 'getHistory'])->name('api.leaves_admin.history');
-    Router::post('/leaves_admin/adjust', [LeaveAdminApiController::class, 'manualAdjustment'])->name('api.leaves_admin.adjust');
-    Router::post('/leaves_admin/calculate', [LeaveAdminApiController::class, 'calculateLeaves'])->name('api.leaves_admin.calculate');
-    Router::post('/leaves_admin/save-entitlements', [LeaveAdminApiController::class, 'saveEntitlements'])->name('api.leaves_admin.save-entitlements');
+    Router::get('/leaves_admin/requests', [LeaveAdminApiController::class, 'listRequests'])->name('api.leaves_admin.requests')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::post('/leaves_admin/requests/{id}/approve', [LeaveAdminApiController::class, 'approveRequest'])->name('api.leaves_admin.approve')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::post('/leaves_admin/requests/{id}/reject', [LeaveAdminApiController::class, 'rejectRequest'])->name('api.leaves_admin.reject')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::post('/leaves_admin/cancellations/{id}/approve', [LeaveAdminApiController::class, 'approveCancellation'])->name('api.leaves_admin.cancellations.approve')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::post('/leaves_admin/cancellations/{id}/reject', [LeaveAdminApiController::class, 'rejectCancellation'])->name('api.leaves_admin.cancellations.reject')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::get('/leaves_admin/entitlements', [LeaveAdminApiController::class, 'listEntitlements'])->name('api.leaves_admin.entitlements')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::post('/leaves_admin/grant-all', [LeaveAdminApiController::class, 'grantForAll'])->name('api.leaves_admin.grant-all')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::get('/leaves_admin/history/{employeeId}', [LeaveAdminApiController::class, 'getHistory'])->name('api.leaves_admin.history')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::post('/leaves_admin/adjust', [LeaveAdminApiController::class, 'manualAdjustment'])->name('api.leaves_admin.adjust')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::post('/leaves_admin/calculate', [LeaveAdminApiController::class, 'calculateLeaves'])->name('api.leaves_admin.calculate')->middleware('auth')->middleware('permission', 'leave_admin');
+    Router::post('/leaves_admin/save-entitlements', [LeaveAdminApiController::class, 'saveEntitlements'])->name('api.leaves_admin.save-entitlements')->middleware('auth')->middleware('permission', 'leave_admin');
 
-    // Littering API routes (user-facing for map, history, etc.)
-    Router::get('/littering', [LitteringApiController::class, 'index'])->name('api.littering.index');
-    Router::post('/littering', [LitteringApiController::class, 'store'])->name('api.littering.store');
-    Router::post('/littering/{id}/process', [LitteringApiController::class, 'process'])->name('api.littering.process');
+    // Littering API routes
+    Router::get('/littering', [LitteringApiController::class, 'index'])->name('api.littering.index')->middleware('auth')->middleware('permission', 'littering_view');
+    Router::post('/littering', [LitteringApiController::class, 'store'])->name('api.littering.store')->middleware('auth')->middleware('permission', 'littering_process');
+    Router::post('/littering/{id}/process', [LitteringApiController::class, 'process'])->name('api.littering.process')->middleware('auth')->middleware('permission', 'littering_process');
 
     // Littering Admin API routes
-    Router::get('/littering_admin/reports', [LitteringAdminApiController::class, 'listReports'])->name('api.littering_admin.reports');
-    Router::post('/littering_admin/reports/{id}/confirm', [LitteringAdminApiController::class, 'confirm'])->name('api.littering_admin.confirm');
-    Router::delete('/littering_admin/reports/{id}', [LitteringAdminApiController::class, 'destroy'])->name('api.littering_admin.destroy');
-    Router::post('/littering_admin/reports/{id}/restore', [LitteringAdminApiController::class, 'restore'])->name('api.littering_admin.restore');
-    Router::delete('/littering_admin/reports/{id}/permanent', [LitteringAdminApiController::class, 'permanentlyDelete'])->name('api.littering_admin.permanent');
+    Router::get('/littering_admin/reports', [LitteringAdminApiController::class, 'listReports'])->name('api.littering_admin.reports')->middleware('auth')->middleware('permission', 'littering_manage');
+    Router::post('/littering_admin/reports/{id}/confirm', [LitteringAdminApiController::class, 'confirm'])->name('api.littering_admin.confirm')->middleware('auth')->middleware('permission', 'littering_manage');
+    Router::delete('/littering_admin/reports/{id}', [LitteringAdminApiController::class, 'destroy'])->name('api.littering_admin.destroy')->middleware('auth')->middleware('permission', 'littering_manage');
+    Router::post('/littering_admin/reports/{id}/restore', [LitteringAdminApiController::class, 'restore'])->name('api.littering_admin.restore')->middleware('auth')->middleware('permission', 'littering_admin');
+    Router::delete('/littering_admin/reports/{id}/permanent', [LitteringAdminApiController::class, 'permanentlyDelete'])->name('api.littering_admin.permanent')->middleware('auth')->middleware('permission', 'littering_admin');
 
-    // Organization API routes (RESTful)
-    Router::get('/organization', [OrganizationApiController::class, 'index'])->name('api.organization.index');
-    Router::post('/organization', [OrganizationApiController::class, 'store'])->name('api.organization.store');
-    Router::put('/organization/{id}', [OrganizationApiController::class, 'update'])->name('api.organization.update');
-    Router::delete('/organization/{id}', [OrganizationApiController::class, 'destroy'])->name('api.organization.destroy');
+    // Organization API routes
+    Router::get('/organization', [OrganizationApiController::class, 'index'])->name('api.organization.index')->middleware('auth');
+    Router::post('/organization', [OrganizationApiController::class, 'store'])->name('api.organization.store')->middleware('auth')->middleware('permission', 'organization_admin');
+    Router::put('/organization/{id}', [OrganizationApiController::class, 'update'])->name('api.organization.update')->middleware('auth')->middleware('permission', 'organization_admin');
+    Router::delete('/organization/{id}', [OrganizationApiController::class, 'destroy'])->name('api.organization.destroy')->middleware('auth')->middleware('permission', 'organization_admin');
 
-    // Role and Permission API routes (RESTful)
-    Router::get('/roles', [RoleApiController::class, 'index'])->name('api.roles.index');
-    Router::post('/roles', [RoleApiController::class, 'store'])->name('api.roles.store');
-    Router::get('/roles/{id}', [RoleApiController::class, 'show'])->name('api.roles.show');
-    Router::put('/roles/{id}', [RoleApiController::class, 'update'])->name('api.roles.update');
-    Router::delete('/roles/{id}', [RoleApiController::class, 'destroy'])->name('api.roles.destroy');
-    Router::put('/roles/{id}/permissions', [RoleApiController::class, 'updatePermissions'])->name('api.roles.permissions');
+    // Role and Permission API routes
+    Router::get('/roles', [RoleApiController::class, 'index'])->name('api.roles.index')->middleware('auth')->middleware('permission', 'role_admin');
+    Router::post('/roles', [RoleApiController::class, 'store'])->name('api.roles.store')->middleware('auth')->middleware('permission', 'role_admin');
+    Router::get('/roles/{id}', [RoleApiController::class, 'show'])->name('api.roles.show')->middleware('auth')->middleware('permission', 'role_admin');
+    Router::put('/roles/{id}', [RoleApiController::class, 'update'])->name('api.roles.update')->middleware('auth')->middleware('permission', 'role_admin');
+    Router::delete('/roles/{id}', [RoleApiController::class, 'destroy'])->name('api.roles.destroy')->middleware('auth')->middleware('permission', 'role_admin');
+    Router::put('/roles/{id}/permissions', [RoleApiController::class, 'updatePermissions'])->name('api.roles.permissions')->middleware('auth')->middleware('permission', 'role_admin');
 
-    // User API routes (RESTful)
-    Router::get('/users', [UserApiController::class, 'index'])->name('api.users.index');
-    Router::get('/users/{id}', [UserApiController::class, 'show'])->name('api.users.show');
-    Router::put('/users/{id}', [UserApiController::class, 'update'])->name('api.users.update');
-    Router::post('/users/{id}/link', [UserApiController::class, 'linkEmployee'])->name('api.users.link');
-    Router::post('/users/{id}/unlink', [UserApiController::class, 'unlinkEmployee'])->name('api.users.unlink');
+    // User API routes
+    Router::get('/users', [UserApiController::class, 'index'])->name('api.users.index')->middleware('auth')->middleware('permission', 'user_admin');
+    Router::get('/users/{id}', [UserApiController::class, 'show'])->name('api.users.show')->middleware('auth')->middleware('permission', 'user_admin');
+    Router::put('/users/{id}', [UserApiController::class, 'update'])->name('api.users.update')->middleware('auth')->middleware('permission', 'user_admin');
+    Router::post('/users/{id}/link', [UserApiController::class, 'linkEmployee'])->name('api.users.link')->middleware('auth')->middleware('permission', 'user_admin');
+    Router::post('/users/{id}/unlink', [UserApiController::class, 'unlinkEmployee'])->name('api.users.unlink')->middleware('auth')->middleware('permission', 'user_admin');
 
     // Menu API routes
-    Router::get('/menus', [MenuApiController::class, 'index'])->name('api.menus.index');
-    Router::post('/menus', [MenuApiController::class, 'store'])->name('api.menus.store');
-    Router::get('/menus/{id}', [MenuApiController::class, 'show'])->name('api.menus.show');
-    Router::post('/menus/order', [MenuApiController::class, 'updateOrder'])->name('api.menus.order');
-    Router::put('/menus/{id}', [MenuApiController::class, 'update'])->name('api.menus.update');
-    Router::delete('/menus/{id}', [MenuApiController::class, 'destroy'])->name('api.menus.destroy');
+    Router::get('/menus', [MenuApiController::class, 'index'])->name('api.menus.index')->middleware('auth')->middleware('permission', 'menu_admin');
+    Router::post('/menus', [MenuApiController::class, 'store'])->name('api.menus.store')->middleware('auth')->middleware('permission', 'menu_admin');
+    Router::get('/menus/{id}', [MenuApiController::class, 'show'])->name('api.menus.show')->middleware('auth')->middleware('permission', 'menu_admin');
+    Router::post('/menus/order', [MenuApiController::class, 'updateOrder'])->name('api.menus.order')->middleware('auth')->middleware('permission', 'menu_admin');
+    Router::put('/menus/{id}', [MenuApiController::class, 'update'])->name('api.menus.update')->middleware('auth')->middleware('permission', 'menu_admin');
+    Router::delete('/menus/{id}', [MenuApiController::class, 'destroy'])->name('api.menus.destroy')->middleware('auth')->middleware('permission', 'menu_admin');
 
     // Profile API routes
-    Router::get('/profile', [ProfileApiController::class, 'index'])->name('api.profile.index');
-    Router::put('/profile', [ProfileApiController::class, 'update'])->name('api.profile.update');
+    Router::get('/profile', [ProfileApiController::class, 'index'])->name('api.profile.index')->middleware('auth');
+    Router::put('/profile', [ProfileApiController::class, 'update'])->name('api.profile.update')->middleware('auth');
 
     // Log API routes
-    Router::get('/logs', [LogApiController::class, 'index'])->name('api.logs.index');
-    Router::delete('/logs', [LogApiController::class, 'destroy'])->name('api.logs.destroy');
+    Router::get('/logs', [LogApiController::class, 'index'])->name('api.logs.index')->middleware('auth')->middleware('permission', 'log_admin');
+    Router::delete('/logs', [LogApiController::class, 'destroy'])->name('api.logs.destroy')->middleware('auth')->middleware('permission', 'log_admin');
 
     // Waste Collection API routes
-    Router::get('/waste-collections', [WasteCollectionApiController::class, 'index'])->name('api.waste-collections.index');
-    Router::post('/waste-collections', [WasteCollectionApiController::class, 'store'])->name('api.waste-collections.store');
-    Router::get('/waste-collections/admin', [WasteCollectionApiController::class, 'getAdminCollections'])->name('api.waste-collections.admin');
-    Router::post('/waste-collections/admin/{id}/process', [WasteCollectionApiController::class, 'processCollection'])->name('api.waste-collections.process');
-    Router::put('/waste-collections/admin/{id}/items', [WasteCollectionApiController::class, 'updateItems'])->name('api.waste-collections.items');
-    Router::put('/waste-collections/admin/{id}/memo', [WasteCollectionApiController::class, 'updateMemo'])->name('api.waste-collections.memo');
-    Router::post('/waste-collections/admin/parse-html', [WasteCollectionApiController::class, 'parseHtmlFile'])->name('api.waste-collections.parse-html');
-    Router::post('/waste-collections/admin/batch-register', [WasteCollectionApiController::class, 'batchRegister'])->name('api.waste-collections.batch-register');
-    Router::delete('/waste-collections/admin/online-submissions', [WasteCollectionApiController::class, 'clearOnlineSubmissions'])->name('api.waste-collections.clear-online');
-
+    Router::get('/waste-collections', [WasteCollectionApiController::class, 'index'])->name('api.waste-collections.index')->middleware('auth');
+    Router::post('/waste-collections', [WasteCollectionApiController::class, 'store'])->name('api.waste-collections.store')->middleware('auth');
+    Router::get('/waste-collections/admin', [WasteCollectionApiController::class, 'getAdminCollections'])->name('api.waste-collections.admin')->middleware('auth')->middleware('permission', 'waste_admin');
+    Router::post('/waste-collections/admin/{id}/process', [WasteCollectionApiController::class, 'processCollection'])->name('api.waste-collections.process')->middleware('auth')->middleware('permission', 'waste_admin');
+    Router::put('/waste-collections/admin/{id}/items', [WasteCollectionApiController::class, 'updateItems'])->name('api.waste-collections.items')->middleware('auth')->middleware('permission', 'waste_admin');
+    Router::put('/waste-collections/admin/{id}/memo', [WasteCollectionApiController::class, 'updateMemo'])->name('api.waste-collections.memo')->middleware('auth')->middleware('permission', 'waste_admin');
+    Router::post('/waste-collections/admin/parse-html', [WasteCollectionApiController::class, 'parseHtmlFile'])->name('api.waste-collections.parse-html')->middleware('auth')->middleware('permission', 'waste_admin');
+    Router::post('/waste-collections/admin/batch-register', [WasteCollectionApiController::class, 'batchRegister'])->name('api.waste-collections.batch-register')->middleware('auth')->middleware('permission', 'waste_admin');
+    Router::delete('/waste-collections/admin/online-submissions', [WasteCollectionApiController::class, 'clearOnlineSubmissions'])->name('api.waste-collections.clear-online')->middleware('auth')->middleware('permission', 'waste_admin');
 });


### PR DESCRIPTION
This commit completes a major refactoring of the application's authorization system and improves the user experience for permission-related errors.

First, it centralizes all authentication and permission checks into a robust middleware system. The new `AuthMiddleware` and `PermissionMiddleware` now protect both web and API routes, ensuring consistent and maintainable access control across the entire application. All redundant `requireAuth()` calls have been removed from controllers, fully separating authorization concerns.

Second, based on user feedback, it improves the 403 Forbidden error page. The `PermissionMiddleware` now renders a custom 403 page within the main application layout, providing a seamless user experience.

Finally, the middlewares are configured to return appropriate JSON-formatted errors (401 Unauthorized, 403 Forbidden) for all API requests, maintaining a clean and predictable API for clients. This comprehensive change improves the application's architecture, security, and user experience.