### PR TITLE
fix(js): Correct path for interactive-map script

### DIFF
--- a/app/Controllers/Web/LitteringController.php
+++ b/app/Controllers/Web/LitteringController.php
@@ -32,7 +32,7 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map-manager.js");
+        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-admin.js");
 
@@ -60,7 +60,7 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/marker-factory.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map-manager.js");
+        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-map.js");
@@ -89,7 +89,7 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/marker-factory.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map-manager.js");
+        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-history.js");
 
@@ -110,7 +110,7 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map-manager.js");
+        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-deleted-admin.js");
 

--- a/app/Controllers/Web/WasteCollectionController.php
+++ b/app/Controllers/Web/WasteCollectionController.php
@@ -32,7 +32,7 @@ class WasteCollectionController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/marker-factory.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map-manager.js");
+        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/waste-collection.js");
 


### PR DESCRIPTION
During the previous refactoring, the file `interactive-map-manager.js` was renamed to `interactive-map.js`.

However, the paths in `LitteringController.php` and `WasteCollectionController.php` were not updated to reflect this change, resulting in a 404 error when trying to load the script.

This commit corrects the script path in both controllers, resolving the error.