### PR TITLE
refactor(js): Hardcode common JS files in main layout

### DIFF
--- a/app/Controllers/Web/AdminController.php
+++ b/app/Controllers/Web/AdminController.php
@@ -29,8 +29,6 @@ class AdminController extends BaseController
     public function organization(): void
     {
         $pageTitle = "부서/직급 관리";
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/organization-admin.js');
         
         // Log menu access
@@ -47,8 +45,6 @@ class AdminController extends BaseController
     public function rolePermissions(): void
     {
         $pageTitle = "역할 및 권한 관리";
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/roles.js');
         
         // Log menu access
@@ -65,8 +61,6 @@ class AdminController extends BaseController
     public function users(): void
     {
         $pageTitle = "사용자 관리";
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/users.js');
         
         // Log menu access
@@ -84,8 +78,6 @@ class AdminController extends BaseController
     {
         $pageTitle = "메뉴 관리";
         \App\Core\View::addJs("https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/menu-admin.js");
         
         // Log menu access

--- a/app/Controllers/Web/EmployeeController.php
+++ b/app/Controllers/Web/EmployeeController.php
@@ -26,8 +26,6 @@ class EmployeeController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/libs/list.js/list.min.js');
 
         // Load BaseApp and dependencies
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
 
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/employees.js');
         

--- a/app/Controllers/Web/HolidayController.php
+++ b/app/Controllers/Web/HolidayController.php
@@ -26,8 +26,6 @@ class HolidayController extends BaseController
         View::addJs(BASE_ASSETS_URL . '/assets/libs/flatpickr/flatpickr.min.js');
 
         // Load BaseApp and dependencies
-        View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
 
         View::addJs(BASE_ASSETS_URL . '/assets/js/pages/holiday-admin.js');
 

--- a/app/Controllers/Web/LeaveController.php
+++ b/app/Controllers/Web/LeaveController.php
@@ -35,8 +35,6 @@ class LeaveController extends BaseController
         $pageTitle = "연차 신청/내역";
         \App\Core\View::addCss(BASE_ASSETS_URL . '/assets/libs/sweetalert2/sweetalert2.min.css');
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/libs/sweetalert2/sweetalert2.min.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/my-leave.js');
 
         // Check permission in the controller, not in the view.
@@ -51,8 +49,6 @@ class LeaveController extends BaseController
     public function approval(): void
     {
         $pageTitle = "연차 신청 승인/반려";
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/leave-approval.js');
 
         echo $this->render('pages/leaves/approval', compact('pageTitle'), 'layouts/app');
@@ -64,8 +60,6 @@ class LeaveController extends BaseController
     public function granting(): void
     {
         $pageTitle = "연차 부여/계산";
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/leave-granting.js');
 
         echo $this->render('pages/leaves/granting', compact('pageTitle'), 'layouts/app');
@@ -77,8 +71,6 @@ class LeaveController extends BaseController
     public function history(): void
     {
         $pageTitle = "직원 연차 내역 조회";
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/leave-history-admin.js');
 
         // Get all employees for the dropdown via the service layer

--- a/app/Controllers/Web/LitteringController.php
+++ b/app/Controllers/Web/LitteringController.php
@@ -31,9 +31,8 @@ class LitteringController extends BaseController
         // Refactored Scripts
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
+        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-admin.js");
 
         echo $this->render('pages/littering/admin', compact('pageTitle'), 'layouts/app');
@@ -59,9 +58,7 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/marker-factory.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-map.js");
 
@@ -88,9 +85,8 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/marker-factory.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
+        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-history.js");
 
         echo $this->render('pages/littering/history', compact('pageTitle'), 'layouts/app');
@@ -109,9 +105,8 @@ class LitteringController extends BaseController
         // Refactored Scripts
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
+        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-deleted-admin.js");
 
         echo $this->render('pages/littering/deleted', compact('pageTitle'), 'layouts/app');

--- a/app/Controllers/Web/LogController.php
+++ b/app/Controllers/Web/LogController.php
@@ -24,8 +24,6 @@ class LogController extends BaseController
         $pageTitle = "사용 로그 뷰어";
 
         // Load BaseApp and dependencies
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/services/api-service.js');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/core/base-page.js');
 
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/log-viewer.js');
         \App\Services\ActivityLogger::logMenuAccess($pageTitle);

--- a/app/Controllers/Web/ProfileController.php
+++ b/app/Controllers/Web/ProfileController.php
@@ -21,8 +21,6 @@ class ProfileController extends BaseController
      */
     public function index(): void
     {
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/profile.js");
 
         $pageTitle = "내 프로필";

--- a/app/Controllers/Web/WasteCollectionController.php
+++ b/app/Controllers/Web/WasteCollectionController.php
@@ -31,9 +31,8 @@ class WasteCollectionController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/touch-manager.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/utils/marker-factory.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/components/interactive-map.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
+        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/waste-collection.js");
 
         $pageTitle = "대형폐기물 수거";
@@ -58,8 +57,6 @@ class WasteCollectionController extends BaseController
     public function admin(): void
     {
         // Refactored Scripts
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/api-service.js");
-        \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/core/base-page.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/waste-admin.js");
         
         $pageTitle = "대형폐기물 관리";

--- a/app/Views/layouts/app.php
+++ b/app/Views/layouts/app.php
@@ -92,6 +92,10 @@ $profileImageUrl = SessionManager::get('user')['profile_image_url'] ?? BASE_ASSE
     <!-- Custom UI js -->
     <script src="<?= BASE_ASSETS_URL ?>/assets/js/utils/ui-helpers.js"></script>
 
+    <!-- Common Application JS -->
+    <script src="<?= BASE_ASSETS_URL ?>/assets/js/services/api-service.js"></script>
+    <script src="<?= BASE_ASSETS_URL ?>/assets/js/core/base-page.js"></script>
+
     <!-- Dynamic JS Section -->
     <?= View::yieldSection('js') ?>
 

--- a/public/assets/js/pages/littering-admin.js
+++ b/public/assets/js/pages/littering-admin.js
@@ -20,7 +20,7 @@ class LitteringAdminPage extends BasePage {
                 document.getElementById('address').value = locationData.address;
             }
         };
-        this.initializeMapManager(mapOptions);
+        this.state.mapService = new MapService(mapOptions);
         this.setupEventListeners();
         this.loadInitialData();
     }
@@ -91,11 +91,11 @@ class LitteringAdminPage extends BasePage {
         this.renderExistingPhotos(selected);
 
         const position = { lat: selected.latitude, lng: selected.longitude };
-        this.state.mapManager.setCenter(position);
+        this.state.mapService.mapManager.setCenter(position);
 
-        if (this.state.currentMarker) this.state.mapManager.removeMarker(this.state.currentMarker);
+        if (this.state.currentMarker) this.state.mapService.mapManager.removeMarker(this.state.currentMarker);
 
-        this.state.currentMarker = this.state.mapManager.addMarker({
+        this.state.currentMarker = this.state.mapService.mapManager.addMarker({
             position: position,
             draggable: true,
             onDragEnd: (newPosition) => {
@@ -188,11 +188,20 @@ class LitteringAdminPage extends BasePage {
         document.getElementById('confirm-form').reset();
         this.state.selectedReport = null;
         if (this.state.currentMarker) {
-            this.state.mapManager.removeMarker(this.state.currentMarker);
+            this.state.mapService.mapManager.removeMarker(this.state.currentMarker);
             this.state.currentMarker = null;
         }
         const activeItem = document.querySelector('#pending-list .active');
         if (activeItem) activeItem.classList.remove('active');
+    }
+    /**
+     * @override
+     */
+    cleanup() {
+        super.cleanup();
+        if (this.state.mapService) {
+            this.state.mapService.destroy();
+        }
     }
 }
 

--- a/public/assets/js/pages/littering-history.js
+++ b/public/assets/js/pages/littering-history.js
@@ -28,7 +28,7 @@ class LitteringHistoryPage extends BasePage {
             markerSize: { width: 34, height: 40 },
             onMarkerClick: (marker, data) => this.openDetailsOffcanvas(data.address, data.items)
         };
-        this.initializeMapManager(mapOptions);
+        this.state.mapService = new MapService(mapOptions);
         this.setupOffcanvas();
         this.setupLightbox();
         this.loadInitialData();
@@ -92,7 +92,7 @@ class LitteringHistoryPage extends BasePage {
         Object.entries(this.state.groupedData).forEach(([address, items]) => {
             const firstItem = items[0];
             const dominantType = this.getDominantWasteType(items);
-            this.state.mapManager.addMarker({
+            this.state.mapService.mapManager.addMarker({
                 position: { lat: firstItem.latitude, lng: firstItem.longitude },
                 type: `${dominantType}_processed`,
                 data: { address, items },
@@ -171,6 +171,15 @@ class LitteringHistoryPage extends BasePage {
 
     formatDateTime(dateTimeString) {
         return dateTimeString ? new Date(dateTimeString).toLocaleString('ko-KR') : 'N/A';
+    }
+    /**
+     * @override
+     */
+    cleanup() {
+        super.cleanup();
+        if (this.state.mapService) {
+            this.state.mapService.destroy();
+        }
     }
 }
 


### PR DESCRIPTION
Moves common JavaScript files (`base-page.js`, `api-service.js`) from individual controller `View::addJs()` calls into the main `app.php` layout directly. This simplifies controller logic and ensures consistent script loading order.

fix(js): Complete MapService migration for all pages

Completes the migration to the new `MapService` for all remaining map-dependent pages (`littering-history`, `littering-admin`, `waste-collection`, etc.) that were missed in the initial refactor. This resolves the critical bug where multiple map pages were broken due to calls to the removed `initializeMapManager` function. All pages are now fully functional with the new architecture.