### PR TITLE
fix(js): Correct syntax error and remove redundant assets

### DIFF
--- a/app/Controllers/Web/LeaveController.php
+++ b/app/Controllers/Web/LeaveController.php
@@ -33,8 +33,6 @@ class LeaveController extends BaseController
     public function my(): void
     {
         $pageTitle = "연차 신청/내역";
-        \App\Core\View::addCss(BASE_ASSETS_URL . '/assets/libs/sweetalert2/sweetalert2.min.css');
-        \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/libs/sweetalert2/sweetalert2.min.js');
         \App\Core\View::addJs(BASE_ASSETS_URL . '/assets/js/pages/my-leave.js');
 
         // Check permission in the controller, not in the view.

--- a/public/assets/js/pages/waste-collection.js
+++ b/public/assets/js/pages/waste-collection.js
@@ -309,7 +309,6 @@ class WasteCollectionPage extends BasePage {
         const today = new Date();
         document.querySelector(selector).value = `${today.getFullYear()}-${String(today.getMonth()+1).padStart(2,'0')}-${String(today.getDate()).padStart(2,'0')}`;
     }
-}
 
     /**
      * @override


### PR DESCRIPTION
- Fixes a JavaScript syntax error in `waste-collection.js` caused by an extra closing brace added by a previous script.
- Removes redundant `View::addCss` and `View::addJs` calls for the `sweetalert2` library from `LeaveController.php`, as it is already loaded globally in the main layout.