### PR TITLE
fix(map): Ensure ALLOWED_REGIONS config is passed to MapService

### DIFF
--- a/public/assets/js/components/interactive-map.js
+++ b/public/assets/js/components/interactive-map.js
@@ -8,7 +8,7 @@
  * - 마커 등록/처리/삭제 관리
  * - 모바일 터치 이벤트 처리
  */
-class InteractiveMapManager {
+class InteractiveMap {
     constructor(options = {}) {
         this.config = {
             // 지도 설정

--- a/public/assets/js/pages/littering-admin.js
+++ b/public/assets/js/pages/littering-admin.js
@@ -15,6 +15,7 @@ class LitteringAdminPage extends BasePage {
 
     initializeApp() {
         const mapOptions = {
+            ...this.config, // Pass all page configs to the map
             enableTempMarker: false,
             onAddressResolved: (locationData) => {
                 document.getElementById('address').value = locationData.address;

--- a/public/assets/js/services/map-service.js
+++ b/public/assets/js/services/map-service.js
@@ -34,7 +34,7 @@ class MapService {
             return;
         }
 
-        this.mapManager = new InteractiveMapManager(this.config);
+        this.mapManager = new InteractiveMap(this.config);
     }
 
     /**


### PR DESCRIPTION
The `ALLOWED_REGIONS` feature was not working because the configuration was not being passed from the page-specific script (`littering-admin.js`) to the `MapService`.

This commit fixes the issue by:
1.  Spreading the page's `this.config` into the `mapOptions` object in `littering-admin.js`, ensuring `ALLOWED_REGIONS` is passed down.
2.  Renaming the class `InteractiveMapManager` to `InteractiveMap` in `interactive-map.js` to match its filename.
3.  Updating the `MapService` to instantiate the correctly named `InteractiveMap` class.