### PR TITLE
refactor(config): Load map allowedRegions from .env via controller

### DIFF
--- a/app/Controllers/Web/LitteringController.php
+++ b/app/Controllers/Web/LitteringController.php
@@ -35,7 +35,7 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-admin.js");
 
-        echo $this->render('pages/littering/admin', compact('pageTitle'), 'layouts/app');
+        echo $this->render('pages/littering/admin', ['pageTitle' => $pageTitle, 'jsConfig' => ['allowedRegions' => ALLOWED_REGIONS]], 'layouts/app');
     }
 
     /**
@@ -62,7 +62,7 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-map.js");
 
-        echo $this->render('pages/littering/map', compact('pageTitle'), 'layouts/app');
+        echo $this->render('pages/littering/map', ['pageTitle' => $pageTitle, 'jsConfig' => ['allowedRegions' => ALLOWED_REGIONS]], 'layouts/app');
     }
 
     /**
@@ -89,7 +89,7 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-history.js");
 
-        echo $this->render('pages/littering/history', compact('pageTitle'), 'layouts/app');
+        echo $this->render('pages/littering/history', ['pageTitle' => $pageTitle, 'jsConfig' => ['allowedRegions' => ALLOWED_REGIONS]], 'layouts/app');
     }
 
     /**
@@ -109,7 +109,7 @@ class LitteringController extends BaseController
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/services/map-service.js");
         \App\Core\View::addJs(BASE_ASSETS_URL . "/assets/js/pages/littering-deleted-admin.js");
 
-        echo $this->render('pages/littering/deleted', compact('pageTitle'), 'layouts/app');
+        echo $this->render('pages/littering/deleted', ['pageTitle' => $pageTitle, 'jsConfig' => ['allowedRegions' => ALLOWED_REGIONS]], 'layouts/app');
     }
 
     /**

--- a/app/Controllers/Web/WasteCollectionController.php
+++ b/app/Controllers/Web/WasteCollectionController.php
@@ -39,7 +39,8 @@ class WasteCollectionController extends BaseController
         \App\Services\ActivityLogger::logMenuAccess($pageTitle);
 
         echo $this->render('pages/waste/collection', [
-            'pageTitle' => $pageTitle
+            'pageTitle' => $pageTitle,
+            'jsConfig' => ['allowedRegions' => ALLOWED_REGIONS]
         ], 'layouts/app');
     }
 

--- a/app/Views/layouts/app.php
+++ b/app/Views/layouts/app.php
@@ -96,6 +96,13 @@ $profileImageUrl = SessionManager::get('user')['profile_image_url'] ?? BASE_ASSE
     <script src="<?= BASE_ASSETS_URL ?>/assets/js/services/api-service.js"></script>
     <script src="<?= BASE_ASSETS_URL ?>/assets/js/core/base-page.js"></script>
 
+    <!-- Conditionally Rendered JS Config from Controller -->
+    <?php if (isset($jsConfig)): ?>
+    <script>
+        window.AppConfig = <?= json_encode($jsConfig) ?>;
+    </script>
+    <?php endif; ?>
+
     <!-- Dynamic JS Section -->
     <?= View::yieldSection('js') ?>
 

--- a/config/config.php
+++ b/config/config.php
@@ -99,3 +99,9 @@ App\Core\SessionManager::regenerate();
 
 // 10. 공통 페이지 변수 설정은 ViewDataService로 이전되었습니다.
 // 이 파일은 이제 전역 설정 및 초기화만 담당합니다.
+
+// 11. 지도 관련 설정
+// .env 파일에서 ALLOWED_REGIONS 값을 읽어옵니다. 값이 없으면 기본값 '정왕1동'을 사용합니다.
+$allowedRegionsStr = $_ENV['ALLOWED_REGIONS'] ?? '정왕1동';
+$allowedRegionsArr = array_filter(array_map('trim', explode(',', $allowedRegionsStr)));
+define('ALLOWED_REGIONS', $allowedRegionsArr);

--- a/public/assets/js/pages/littering-admin.js
+++ b/public/assets/js/pages/littering-admin.js
@@ -1,8 +1,7 @@
 class LitteringAdminPage extends BasePage {
     constructor() {
         super({
-            API_URL: '/littering_admin/reports',
-            allowedRegions: ['정왕1동']
+            API_URL: '/littering_admin/reports'
         });
 
         this.state = {

--- a/public/assets/js/pages/littering-map.js
+++ b/public/assets/js/pages/littering-map.js
@@ -7,8 +7,7 @@ class LitteringMapPage extends BasePage {
         super({
             API_URL: '/littering',
             WASTE_TYPES: ['생활폐기물', '음식물', '재활용', '대형', '소각'],
-            FILE: { MAX_SIZE: 5 * 1024 * 1024, ALLOWED_TYPES: ['image/jpeg', 'image/png'], COMPRESS: { MAX_WIDTH: 1200, MAX_HEIGHT: 1200, QUALITY: 0.8 } },
-            allowedRegions: ['정왕1동'] // Add region restriction
+            FILE: { MAX_SIZE: 5 * 1024 * 1024, ALLOWED_TYPES: ['image/jpeg', 'image/png'], COMPRESS: { MAX_WIDTH: 1200, MAX_HEIGHT: 1200, QUALITY: 0.8 } }
         });
         this.state = { ...this.state, reportList: [], modals: {}, currentReportIndex: null, mapService: null };
     }

--- a/public/assets/js/services/map-service.js
+++ b/public/assets/js/services/map-service.js
@@ -13,10 +13,15 @@ class MapService {
      * @param {number} [config.level] - The initial zoom level of the map.
      */
     constructor(config = {}) {
-        this.config = {
+        const defaults = {
             mapId: 'map',
             center: { lat: 37.340187, lng: 126.743888 },
             level: 3,
+            allowedRegions: window.AppConfig?.allowedRegions || ['정왕1동'] // Use global config or hardcoded default
+        };
+
+        this.config = {
+            ...defaults,
             ...config
         };
 


### PR DESCRIPTION
Refactors the `allowedRegions` map configuration to be driven by a `.env` variable, passed down through the controller, providing a flexible and environment-specific way to manage map restrictions.

- **`config/config.php`:** Reads `ALLOWED_REGIONS` from `$_ENV` and defines a PHP constant.
- **Layout:** Removes global JS config and adds a conditional block to create `window.AppConfig` only when a `$jsConfig` variable is passed from a controller.
- **Controllers:** Map-related controllers (`LitteringController`, `WasteCollectionController`) now pass the `ALLOWED_REGIONS` constant to their views via the `$jsConfig` variable.
- **JavaScript:** `map-service.js` is updated to use `window.AppConfig` if available, otherwise falling back to a hardcoded default, ensuring stability. Hardcoded `allowedRegions` are removed from page scripts.