### PR TITLE
refactor(js): Cleanup remaining BaseApp legacy code

### DIFF
--- a/public/assets/js/pages/leave-approval.js
+++ b/public/assets/js/pages/leave-approval.js
@@ -1,4 +1,4 @@
-class LeaveApprovalApp extends BaseApp {
+class LeaveApprovalPage extends BasePage {
     constructor() {
         super({
             API_URL: '/leaves_admin'
@@ -162,4 +162,4 @@ class LeaveApprovalApp extends BaseApp {
     }
 }
 
-new LeaveApprovalApp();
+new LeaveApprovalPage();

--- a/public/assets/js/pages/roles.js
+++ b/public/assets/js/pages/roles.js
@@ -1,4 +1,4 @@
-class RolesAdminApp extends BaseApp {
+class RolesAdminPage extends BasePage {
     constructor() {
         super({
             API_URL: '/roles'
@@ -222,4 +222,4 @@ class RolesAdminApp extends BaseApp {
     }
 }
 
-new RolesAdminApp();
+new RolesAdminPage();

--- a/public/assets/js/pages/users.js
+++ b/public/assets/js/pages/users.js
@@ -1,4 +1,4 @@
-class UsersAdminApp extends BaseApp {
+class UsersAdminPage extends BasePage {
     constructor() {
         super({
             API_URL: '/users',
@@ -244,4 +244,4 @@ class UsersAdminApp extends BaseApp {
     }
 }
 
-new UsersAdminApp();
+new UsersAdminPage();


### PR DESCRIPTION
Completes the migration from the legacy `BaseApp` class to the new `BasePage` class for the remaining JavaScript files that were missed during the initial refactoring.

- Updated `users.js`, `leave-approval.js`, and `roles.js` to extend `BasePage`.
- Renamed the classes within these files from `...App` to `...Page` to align with the new naming convention.
- Ensured all page-specific scripts now consistently follow the new architecture.