### PR TITLE
fix(littering): Fix waste_type not saving and collectDate error

### DIFF
--- a/app/Services/LitteringService.php
+++ b/app/Services/LitteringService.php
@@ -186,7 +186,7 @@ class LitteringService
         $data = [
             'id'          => $caseId,
             'corrected'   => Validator::sanitizeString($postData['corrected']),
-            'collectDate' => $postData['collectDate'],
+            'collectDate' => $postData['collectDate'] ?? null,
             'note'        => Validator::sanitizeString($postData['note'] ?? ''),
             'procFileName' => (isset($files['procPhoto']) && $files['procPhoto']['error'] === UPLOAD_ERR_OK)
                 ? FileUploader::validateAndUpload($files['procPhoto'], 'littering', 'proc_') : ''

--- a/public/assets/js/pages/littering-map.js
+++ b/public/assets/js/pages/littering-map.js
@@ -267,6 +267,11 @@ class LitteringMapPage extends BasePage {
         formData.append('lat', document.getElementById('lat').value);
         formData.append('lng', document.getElementById('lng').value);
         formData.append('address', document.getElementById('address').textContent);
+        formData.append('waste_type', document.getElementById('waste_type').value);
+        if (document.getElementById('mixed').checked) {
+            formData.append('waste_type2', document.getElementById('waste_type2').value);
+        }
+
 
         const photo1Input = document.getElementById('regPhoto1');
         if (photo1Input.files.length > 0) formData.set('photo1', photo1Input.files[0]);


### PR DESCRIPTION
This commit fixes two bugs related to the littering feature:

1.  `waste_type` and `waste_type2` data was not being saved when creating a new littering report from the map. This was because the `buildRegistrationFormData` function in `public/assets/js/pages/littering-map.js` was not including these fields in the form data. The function has been updated to explicitly append these values.

2.  A PHP warning ("Undefined array key 'collectDate'") was occurring when processing a littering report. This was caused by directly accessing the `collectDate` key without checking for its existence. This has been fixed in `app/Services/LitteringService.php` by using the null coalescing operator to provide a default null value.