### PR TITLE
refactor: `$_ENV` 직접 접근을 설정 상수로 변경

### DIFF
--- a/app/Controllers/Web/LitteringController.php
+++ b/app/Controllers/Web/LitteringController.php
@@ -36,7 +36,7 @@ class LitteringController extends BaseController
         View::getInstance()->addCss(BASE_ASSETS_URL . "/assets/css/pages/split-layout.css");
         
         View::getInstance()->addJs("https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js");
-        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . ($_ENV['KAKAO_MAP_API_KEY'] ?? '') . "&libraries=services");
+        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . KAKAO_MAP_API_KEY . "&libraries=services");
 
         // Refactored Scripts
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
@@ -62,7 +62,7 @@ class LitteringController extends BaseController
         
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/libs/swiper/swiper-bundle.min.js");
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/libs/glightbox/js/glightbox.min.js");
-        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . ($_ENV['KAKAO_MAP_API_KEY'] ?? '') . "&libraries=services");
+        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . KAKAO_MAP_API_KEY . "&libraries=services");
 
         // Refactored Scripts
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
@@ -89,7 +89,7 @@ class LitteringController extends BaseController
         
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/libs/swiper/swiper-bundle.min.js");
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/libs/glightbox/js/glightbox.min.js");
-        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . ($_ENV['KAKAO_MAP_API_KEY'] ?? '') . "&libraries=services");
+        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . KAKAO_MAP_API_KEY . "&libraries=services");
 
         // Refactored Scripts
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");
@@ -110,7 +110,7 @@ class LitteringController extends BaseController
         $pageTitle = "삭제된 부적정배출";
         $this->activityLogger->logMenuAccess($pageTitle);
 
-        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . ($_ENV['KAKAO_MAP_API_KEY'] ?? '') . "&libraries=services");
+        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . KAKAO_MAP_API_KEY . "&libraries=services");
 
         // Refactored Scripts
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");

--- a/app/Controllers/Web/WasteCollectionController.php
+++ b/app/Controllers/Web/WasteCollectionController.php
@@ -34,7 +34,7 @@ class WasteCollectionController extends BaseController
 
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/libs/swiper/swiper-bundle.min.js");
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/libs/glightbox/js/glightbox.min.js");
-        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . ($_ENV['KAKAO_MAP_API_KEY'] ?? '') . "&libraries=services");
+        View::getInstance()->addJs("//dapi.kakao.com/v2/maps/sdk.js?appkey=" . KAKAO_MAP_API_KEY . "&libraries=services");
 
         // Refactored Scripts
         View::getInstance()->addJs(BASE_ASSETS_URL . "/assets/js/utils/location-utils.js");

--- a/app/Core/Database.php
+++ b/app/Core/Database.php
@@ -9,19 +9,18 @@ class Database {
     private PDO $pdo;
 
     public function __construct() {
-        // Use $_ENV for consistency with the rest of the application
         $dsn = sprintf(
-            'mysql:host=%s;dbname=%s;charset=utf8mb4',
-            $_ENV['DB_HOST'],
-            $_ENV['DB_NAME']
+            'mysql:host=%s;dbname=%s;charset=%s',
+            DB_HOST,
+            DB_NAME,
+            DB_CHARSET
         );
         $options = [
             PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
             PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
             PDO::ATTR_EMULATE_PREPARES   => false,
         ];
-        // Use $_ENV for credentials
-        $this->pdo = new PDO($dsn, $_ENV['DB_USER'], $_ENV['DB_PASS'], $options);
+        $this->pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
     }
 
     private function executeQuery(string $sql, array $params = []): PDOStatement {

--- a/app/Services/KakaoAuthService.php
+++ b/app/Services/KakaoAuthService.php
@@ -10,9 +10,9 @@ class KakaoAuthService
 
     public function __construct()
     {
-        $this->clientId = $_ENV['KAKAO_CLIENT_ID'];
-        $this->clientSecret = $_ENV['KAKAO_CLIENT_SECRET'];
-        $this->redirectUri = $_ENV['KAKAO_REDIRECT_URI'];
+        $this->clientId = KAKAO_CLIENT_ID;
+        $this->clientSecret = KAKAO_CLIENT_SECRET;
+        $this->redirectUri = KAKAO_REDIRECT_URI;
     }
 
     public function getAuthorizationUrl(): string

--- a/config/config.php
+++ b/config/config.php
@@ -40,7 +40,9 @@ define('DB_CHARSET', $_ENV['DB_CHARSET'] ?? 'utf8mb4');
 
 // 4. 카카오 인증 설정 (.env 파일 사용)
 define('KAKAO_CLIENT_ID', $_ENV['KAKAO_CLIENT_ID'] ?? '');
+define('KAKAO_CLIENT_SECRET', $_ENV['KAKAO_CLIENT_SECRET'] ?? '');
 define('KAKAO_REDIRECT_URI', $_ENV['KAKAO_REDIRECT_URI'] ?? '');
+define('KAKAO_MAP_API_KEY', $_ENV['KAKAO_MAP_API_KEY'] ?? '');
 
 // 5. 파일 업로드 설정
 define('UPLOAD_DIR', ROOT_PATH . '/public/uploads/'); // 파일 시스템 절대 경로


### PR DESCRIPTION
`config/config.php`에 모든 환경 변수 기반 설정을 상수로 정의하고, 애플리케이션 전체에서 `$_ENV`나 `getenv()` 대신 이 상수들을 사용하도록 리팩토링했습니다.

- `config/config.php`: `KAKAO_MAP_API_KEY`, `KAKAO_CLIENT_SECRET` 상수 추가
- `app/Core/Database.php`: DB 연결 정보에 `DB_*` 상수 사용
- `app/Services/KakaoAuthService.php`: 카카오 인증 정보에 `KAKAO_*` 상수 사용
- `app/Controllers/Web/`: 컨트롤러에서 카카오맵 API 키에 `KAKAO_MAP_API_KEY` 상수 사용

이를 통해 설정 관리의 일관성을 높이고 코드 유지보수성을 향상시켰습니다.