### PR TITLE
feat: Add unlinked method to EmployeeApiController

### DIFF
--- a/app/Controllers/Api/EmployeeApiController.php
+++ b/app/Controllers/Api/EmployeeApiController.php
@@ -113,5 +113,15 @@ class EmployeeApiController extends BaseApiController
         }
     }
 
+    public function unlinked(): void
+    {
+        try {
+            $unlinkedEmployees = $this->employeeService->getUnlinkedEmployees();
+            $this->apiSuccess($unlinkedEmployees);
+        } catch (Exception $e) {
+            $this->handleException($e);
+        }
+    }
+
     // ... (rest of the original methods are assumed to be here)
 }


### PR DESCRIPTION
Implements the `unlinked` method in `EmployeeApiController` to handle requests to the `/api/employees/unlinked` endpoint. This resolves the 'Cannot find controller or method' error. The new method leverages the existing `getUnlinkedEmployees` method in `EmployeeService` to fetch employees who are not linked to any user account.