### PR TITLE
fix(waste): Add missing collection completion button

### DIFF
--- a/public/assets/js/pages/waste-index.js
+++ b/public/assets/js/pages/waste-index.js
@@ -180,7 +180,22 @@ class WasteCollectionPage extends BasePage {
             const itemsContent = items.map(item => `<li class="list-group-item d-flex justify-content-between align-items-center p-1">${item.name}<span class="badge bg-secondary rounded-pill">${item.quantity}</span></li>`).join('');
             const typeBadge = c.type === 'field' ? `<span class="badge bg-info">현장등록</span>` : `<span class="badge bg-success">인터넷배출</span>`;
             const feeBadge = (c.type === 'online' && c.fee > 0) ? `<span class="badge bg-dark ms-1">${c.fee.toLocaleString()}원</span>` : '';
-            return `<div class="card mb-2"><div class="card-body p-2"><div class="d-flex justify-content-between"><div>${typeBadge}${feeBadge}</div><small>${new Date(c.issue_date).toLocaleDateString()}</small></div><ul class="list-group list-group-flush">${itemsContent || '<li>품목 없음</li>'}</ul></div></div>`;
+
+            let cardFooter = '';
+            if (c.type === 'field' && c.status === 'unprocessed') {
+                cardFooter = `<div class="card-footer p-2 text-end"><button class="btn btn-sm btn-primary" onclick="window.wasteCollectionApp.processFieldCollection(${c.id})">수거 완료</button></div>`;
+            }
+
+            return `<div class="card mb-2">
+                        <div class="card-body p-2">
+                            <div class="d-flex justify-content-between">
+                                <div>${typeBadge}${feeBadge}</div>
+                                <small>${new Date(c.issue_date).toLocaleDateString()}</small>
+                            </div>
+                            <ul class="list-group list-group-flush">${itemsContent || '<li>품목 없음</li>'}</ul>
+                        </div>
+                        ${cardFooter}
+                    </div>`;
         }).join('');
 
         const headerTitle = isCluster ? `${first.address} (${collections.length}건)` : first.address;
@@ -193,6 +208,24 @@ class WasteCollectionPage extends BasePage {
         if (this.state.currentOverlay) {
             this.state.currentOverlay.setMap(null);
             this.state.currentOverlay = null;
+        }
+    }
+
+    async processFieldCollection(collectionId) {
+        try {
+            await this.apiCall(`/waste-collections/admin/${collectionId}/process`, { method: 'POST' });
+            Toast.success('수거 완료 처리되었습니다.');
+            this.closeOverlay();
+
+            // Find and remove the marker from the map
+            const index = this.state.collectionList.findIndex(item => !item.isCluster && item.data.id === collectionId);
+            if (index > -1) {
+                const collectionInfo = this.state.collectionList[index];
+                this.state.mapService.mapManager.removeMarker(collectionInfo.marker);
+                this.state.collectionList.splice(index, 1);
+            }
+        } catch (error) {
+            Toast.error(`처리 실패: ${error.message}`);
         }
     }
 


### PR DESCRIPTION
This commit fixes an issue where the "Collection Complete" button was not visible for on-site registered large waste items on the `/waste/index` page.

The `openCollectionOverlay` function in `waste-index.js` has been updated to dynamically add the button to the overlay for unprocessed, on-site collections. A new `processFieldCollection` method has been added to handle the API call to mark the item as processed and update the UI by removing the marker from the map.