### PR TITLE
Refactor: 데이터베이스 스키마 재작성 및 역할 분리 강화

### DIFF
--- a/app/Models/Leave.php
+++ b/app/Models/Leave.php
@@ -12,7 +12,7 @@ class Leave extends BaseModel
         'days_count',
         'reason',
         'status',
-        'approved_by',
+        'approver_employee_id',
         'rejection_reason',
         'cancellation_reason'
     ];
@@ -30,7 +30,7 @@ class Leave extends BaseModel
         'days_count' => 'required|numeric',
         'reason' => 'string',
         'status' => 'in:pending,approved,rejected,cancelled,cancellation_requested',
-        'approved_by' => 'integer'
+        'approver_employee_id' => 'integer'
     ];
 
     /**

--- a/app/Models/WasteCollection.php
+++ b/app/Models/WasteCollection.php
@@ -4,20 +4,23 @@ namespace App\Models;
 class WasteCollection extends BaseModel
 {
     protected array $fillable = [
+        'type',
         'latitude',
         'longitude',
         'address',
-        'photo_path',
-        'employee_id',
+        'geocoding_status',
         'issue_date',
+        'photo_path',
         'discharge_number',
         'submitter_name',
         'submitter_phone',
         'fee',
         'status',
-        'type',
-        'geocoding_status',
-        'admin_memo'
+        'admin_memo',
+        'created_by',
+        'completed_by',
+        'created_at',
+        'completed_at'
     ];
 
     protected array $hidden = [];

--- a/app/Repositories/EmployeeChangeLogRepository.php
+++ b/app/Repositories/EmployeeChangeLogRepository.php
@@ -12,13 +12,13 @@ class EmployeeChangeLogRepository {
     /**
      * 직원 정보 변경 로그를 기록합니다.
      */
-    public function insert(int $employeeId, int $changerId, string $fieldName, ?string $oldValue, ?string $newValue): bool {
-        $sql = "INSERT INTO hr_employee_change_logs (employee_id, changer_id, field_name, old_value, new_value)
-                VALUES (:employee_id, :changer_id, :field_name, :old_value, :new_value)";
+    public function insert(int $employeeId, int $changerEmployeeId, string $fieldName, ?string $oldValue, ?string $newValue): bool {
+        $sql = "INSERT INTO hr_employee_change_logs (employee_id, changer_employee_id, field_name, old_value, new_value)
+                VALUES (:employee_id, :changer_employee_id, :field_name, :old_value, :new_value)";
         
         return $this->db->execute($sql, [
             ':employee_id' => $employeeId,
-            ':changer_id' => $changerId,
+            ':changer_employee_id' => $changerEmployeeId,
             ':field_name' => $fieldName,
             ':old_value' => $oldValue,
             ':new_value' => $newValue
@@ -29,9 +29,9 @@ class EmployeeChangeLogRepository {
      * 특정 직원의 모든 변경 이력을 조회합니다.
      */
     public function findByEmployeeId(int $employeeId): array {
-        $sql = "SELECT l.*, u.nickname as changer_name 
+        $sql = "SELECT l.*, e.name as changer_name
                 FROM hr_employee_change_logs l
-                LEFT JOIN sys_users u ON l.changer_id = u.id
+                LEFT JOIN hr_employees e ON l.changer_employee_id = e.id
                 WHERE l.employee_id = :employee_id 
                 ORDER BY l.changed_at DESC";
         return $this->db->query($sql, [':employee_id' => $employeeId]);

--- a/app/Repositories/LeaveRepository.php
+++ b/app/Repositories/LeaveRepository.php
@@ -158,15 +158,15 @@ class LeaveRepository {
      * @param int $adminId 조정을 수행한 관리자의 ID
      * @return bool 로그 기록 성공 여부
      */
-    public function logAdjustment(int $employeeId, int $year, float $adjustedDays, string $reason, int $adminId): bool {
-        $sql = "INSERT INTO hr_leave_adjustments_log (employee_id, year, adjusted_days, reason, admin_id)
-                VALUES (:employee_id, :year, :adjusted_days, :reason, :admin_id)";
+    public function logAdjustment(int $employeeId, int $year, float $adjustedDays, string $reason, int $adminEmployeeId): bool {
+        $sql = "INSERT INTO hr_leave_adjustments_log (employee_id, year, adjusted_days, reason, admin_employee_id)
+                VALUES (:employee_id, :year, :adjusted_days, :reason, :admin_employee_id)";
         return $this->db->execute($sql, [
             ':employee_id' => $employeeId,
             ':year' => $year,
             ':adjusted_days' => $adjustedDays,
             ':reason' => $reason,
-            ':admin_id' => $adminId
+            ':admin_employee_id' => $adminEmployeeId
         ]) > 0;
     }
 
@@ -196,9 +196,9 @@ class LeaveRepository {
      * @return array 해당 직원의 연차 신청 목록
      */
     public function findByEmployeeId(int $employeeId, array $filters = []): array {
-         $sql = "SELECT l.*, u.nickname as approver_name
+         $sql = "SELECT l.*, approver.name as approver_name
                 FROM hr_leaves l
-                LEFT JOIN sys_users u ON l.approved_by = u.id
+                LEFT JOIN hr_employees approver ON l.approver_employee_id = approver.id
                 WHERE l.employee_id = :employee_id";
 
         $params = [':employee_id' => $employeeId];
@@ -275,15 +275,15 @@ class LeaveRepository {
      * @param string|null $rejectionReason 반려 사유 (반려 시에만 사용)
      * @return bool 업데이트 성공 여부
      */
-    public function updateStatus(int $id, string $status, ?int $adminUserId, ?string $rejectionReason): bool {
+    public function updateStatus(int $id, string $status, ?int $adminEmployeeId, ?string $rejectionReason): bool {
         $sql = "UPDATE hr_leaves
-                SET status = :status, approved_by = :approved_by, rejection_reason = :rejection_reason
+                SET status = :status, approver_employee_id = :approver_employee_id, rejection_reason = :rejection_reason
                 WHERE id = :id";
 
         return $this->db->execute($sql, [
             ':id' => $id,
             ':status' => $status,
-            ':approved_by' => $adminUserId,
+            ':approver_employee_id' => $adminEmployeeId,
             ':rejection_reason' => $rejectionReason
         ]) > 0;
     }

--- a/app/Repositories/WasteCollectionRepository.php
+++ b/app/Repositories/WasteCollectionRepository.php
@@ -119,17 +119,17 @@ class WasteCollectionRepository {
     }
 
     public function processByAddress(string $address, int $employeeId): bool {
-        $query = "UPDATE `waste_collections` SET `status` = 'processed', `updated_at` = NOW(), `updated_by` = ? WHERE `address` = ? AND `status` = 'unprocessed'";
+        $query = "UPDATE `waste_collections` SET `status` = 'processed', `completed_at` = NOW(), `completed_by` = ? WHERE `address` = ? AND `status` = 'unprocessed'";
         return $this->db->execute($query, [$employeeId, $address]) > 0;
     }
 
     public function processById(int $id, int $employeeId): bool {
-        $query = "UPDATE `waste_collections` SET `status` = 'processed', `updated_at` = NOW(), `updated_by` = ? WHERE `id` = ? AND `status` = 'unprocessed'";
+        $query = "UPDATE `waste_collections` SET `status` = 'processed', `completed_at` = NOW(), `completed_by` = ? WHERE `id` = ? AND `status` = 'unprocessed'";
         return $this->db->execute($query, [$employeeId, $id]) > 0;
     }
 
     public function updateAdminMemo(int $id, string $memo, int $employeeId): bool {
-        $query = "UPDATE `waste_collections` SET `admin_memo` = ?, `updated_at` = NOW(), `updated_by` = ? WHERE `id` = ?";
+        $query = "UPDATE `waste_collections` SET `admin_memo` = ?, `completed_at` = NOW(), `completed_by` = ? WHERE `id` = ?";
         return $this->db->execute($query, [$memo, $employeeId, $id]) > 0;
     }
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -81,7 +81,7 @@
 
 ### 3.3. 공통 컬럼 설계
 
--   **감사 (Auditing)**: 생성자(`created_by`), 수정자(`updated_by`) 컬럼에는 `employee_id`를 저장하여 모든 변경 사항을 추적합니다.
+-   **감사 (Auditing)**: 생성자(`created_by`), 처리자(`completed_by` 등) 컬럼에는 `employee_id`를 저장하여 모든 데이터 변경 이력을 추적합니다.
 -   **소프트 삭제 (Soft Delete)**: `status` 컬럼을 `deleted`로 변경하고 `deleted_at` 타임스탬프를 기록합니다. 데이터를 조회할 때는 반드시 `WHERE deleted_at IS NULL` 조건을 포함해야 합니다.
 -   **워크플로우 추적**: 상태 변경을 추적하는 컬럼은 `processed_by`, `processed_at`와 같이 상태 값과 의미가 명확하게 연결되도록 명명합니다.
 

--- a/docs/SCHEMA_CHANGES.md
+++ b/docs/SCHEMA_CHANGES.md
@@ -4,8 +4,9 @@
 
 - **목표**: 코드베이스와의 일관성 확보 및 가독성 향상
 - **주요 변경 사항**:
-    - **주석 및 순서 정리**: `database/schema.sql`의 모든 테이블에 대해 필드 주석을 명확하게 수정하고, 필드 순서를 논리적 그룹(ID, 외래 키, 주요 데이터, 타임스탬프 등)으로 재배열했습니다.
-    - **미사용 필드 제거**: `illegal_disposal_cases2` 테이블과 `Littering` 모델을 정밀 재검토하여, 실제 데이터베이스 로직에서 사용되지 않는 `rejection_reason`과 `mixed` 필드를 최종적으로 제거했습니다.
-    - **코드 동기화**: `app/Models/Littering.php` 모델의 `$fillable`, `$rules` 배열 및 관련 메소드를 수정하여 새로운 스키마와 일치시켰습니다.
-    - **시더 업데이트**: `database/seeds/06_employees.sql`, `07_users.sql` 파일의 `INSERT` 구문을 변경된 필드 순서에 맞게 수정했습니다.
-- **영향**: 이 변경으로 인해 데이터베이스 스키마와 애플리케이션 코드 간의 일관성이 확보되었으며, 향후 유지보수성이 향상되었습니다.
+    - **스키마 재정렬 및 주석 개선**: `database/schema.sql`의 모든 테이블에 대해 필드 주석을 명확하게 수정하고, 필드 순서를 논리적 그룹으로 재배열했습니다.
+    - **미사용 필드 제거**: `illegal_disposal_cases2` 테이블과 `Littering` 모델에서 실제 사용되지 않는 `rejection_reason`, `mixed` 필드를 최종적으로 제거했습니다.
+    - **필드명 표준화 (waste_collections)**: `waste_collections` 테이블의 `updated_at`, `updated_by`를 `completed_at`, `completed_by`로 변경하여 '완료' 상태를 명확히 표현했습니다.
+    - **참조 기준 변경 (user_id -> employee_id)**: 데이터의 행위 주체를 시스템 계정(`user`)에서 실제 직원(`employee`)으로 명확히 하기 위해, `hr_leaves`, `hr_employee_change_logs` 등 데이터 관련 테이블의 담당자 참조 컬럼(`approved_by` 등)을 `employee_id`를 참조하도록 수정했습니다.
+    - **코드 및 시더 동기화**: 위의 모든 스키마 변경 사항을 관련 모델, Repository, 시더 파일에 모두 반영하여 시스템 전반의 정합성을 유지했습니다.
+- **영향**: 데이터 모델의 역할(시스템 접근 vs. 업무 처리)이 명확해지고, 스키마의 일관성과 유지보수성이 크게 향상되었습니다.


### PR DESCRIPTION
데이터베이스 스키마(`database/schema.sql`) 전체를 리팩토링하여 가독성과 일관성을 향상시키고, 데이터 행위 주체의 역할을 명확히 분리했습니다. 변경 이력은 `docs/SCHEMA_CHANGES.md`에 상세히 기록했습니다.

주요 변경 사항:
- **스키마 재정렬 및 주석 개선**: 모든 테이블의 필드 주석을 명확하게 수정하고, 필드 순서를 논리적 그룹으로 재배열했습니다.
- **미사용 필드 제거**: `illegal_disposal_cases2` 테이블과 `Littering` 모델에서 실제 사용되지 않는 `rejection_reason`, `mixed` 필드를 최종적으로 제거했습니다.
- **필드명 표준화 (waste_collections)**: `waste_collections` 테이블의 `updated_at`, `updated_by`를 `completed_at`, `completed_by`로 변경하여 '완료' 상태를 명확히 표현했습니다.
- **참조 기준 변경 (user_id -> employee_id)**: 데이터의 행위 주체를 시스템 접근 계정(`user`)에서 실제 직원(`employee`)으로 명확히 분리하기 위해, `hr_leaves`, `hr_employee_change_logs` 등 데이터 관련 테이블의 담당자 참조 컬럼(`approved_by` 등)을 `employee_id`를 참조하도록 수정했습니다.
- **코드 및 시더 동기화**: 위의 모든 스키마 변경 사항을 관련 모델, Repository, 시더 파일에 모두 반영하여 시스템 전반의 정합성을 유지했습니다.
- **문서화**: `docs/SCHEMA_CHANGES.md` 파일을 생성하여 스키마 리팩토링 이력을 상세히 기록하고, `docs/GUIDE.md`의 관련 내용도 수정했습니다.