### PR TITLE
fix(api): Correctly retrieve JSON body in PositionApiController

### DIFF
--- a/app/Controllers/Api/PositionApiController.php
+++ b/app/Controllers/Api/PositionApiController.php
@@ -18,7 +18,7 @@ class PositionApiController {
     }
 
     public function store() {
-        $data = $this->request->getBody();
+        $data = $this->request->all();
         $result = $this->positionService->createPosition($data);
 
         if (isset($result['errors'])) {
@@ -29,7 +29,7 @@ class PositionApiController {
     }
 
     public function update(int $id) {
-        $data = $this->request->getBody();
+        $data = $this->request->all();
         $result = $this->positionService->updatePosition($id, $data);
 
         if (isset($result['errors'])) {


### PR DESCRIPTION
- Resolves a fatal error caused by calling a non-existent `getBody()` method on the `Request` object.
- Updates the `store` and `update` methods in `PositionApiController` to use the correct `all()` method for retrieving the JSON request body.
- This ensures that creating and updating positions via the API now works as intended.