### PR TITLE
fix: Resolve all fatal errors and finalize organization refactor

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -120,9 +120,13 @@ $container->register(\App\Controllers\Web\AdminController::class, fn($c) => new 
 
 // Register API Controllers
 $container->register(\App\Controllers\Api\PositionApiController::class, fn($c) => new \App\Controllers\Api\PositionApiController(
-    $c->resolve(\App\Services\PositionService::class),
     $c->resolve(Request::class),
-    $c->resolve(JsonResponse::class)
+    $c->resolve(\App\Services\AuthService::class),
+    $c->resolve(\App\Services\ViewDataService::class),
+    $c->resolve(\App\Services\ActivityLogger::class),
+    $c->resolve(\App\Repositories\EmployeeRepository::class),
+    $c->resolve(JsonResponse::class),
+    $c->resolve(\App\Services\PositionService::class)
 ));
 $container->register(\App\Controllers\Api\EmployeeApiController::class, fn($c) => new \App\Controllers\Api\EmployeeApiController(
     $c->resolve(Request::class),


### PR DESCRIPTION
This commit resolves a series of fatal errors and completes the requested refactoring of the organization management features.

- **`fix(api)`**: Corrects fatal errors in `PositionApiController` by refactoring it to extend `BaseApiController`, use the correct helper methods (`apiSuccess`, `apiError`) for JSON responses, and use the `all()` method to correctly parse the request body.
- **`fix(js)`**: Resolves a JavaScript TypeError on the organization admin page by refactoring `organization-admin.js` to handle the department and position modals independently.
- **`fix(view)`**: Fixes fatal errors in view rendering by ensuring controllers extend `BaseController` and removing invalid static method calls from view files.
- **`refactor(organization)`**: Integrates position management into the main 'Department & Position Management' page, using a modal for CRUD operations and removing the now-redundant separate pages and controllers.
- **`feat(positions)`**: Implements a `level` attribute for positions and centralizes all employee sorting logic to use this new level for consistent ordering.