### PR TITLE
fix(positions): Correct update logic for unchanged data

### DIFF
--- a/app/Repositories/PositionRepository.php
+++ b/app/Repositories/PositionRepository.php
@@ -25,8 +25,16 @@ class PositionRepository {
     }
 
     public function update(int $id, string $name, int $level): bool {
+        // First, check if the position exists
+        if (!$this->findById($id)) {
+            return false;
+        }
+
+        // If it exists, perform the update.
+        // The operation is successful even if 0 rows are affected (i.e., data is the same).
         $sql = "UPDATE hr_positions SET name = :name, level = :level WHERE id = :id";
-        return $this->db->execute($sql, [':id' => $id, ':name' => $name, ':level' => $level]) > 0;
+        $this->db->execute($sql, [':id' => $id, ':name' => $name, ':level' => $level]);
+        return true;
     }
 
     public function isEmployeeAssigned(int $id): bool {


### PR DESCRIPTION
- Modifies the `PositionRepository::update` method to correctly handle cases where an update is requested but no data is changed.
- Previously, the method returned `false` if the database reported 0 affected rows, causing the API to incorrectly report a failure.
- The updated logic now first verifies the position exists and then returns `true` for the update operation, ensuring idempotency and preventing spurious error messages for the user.