### PR TITLE
Hotfix: EmployeeApiController에서 존재하지 않는 메소드 호출 수정

### DIFF
--- a/app/Controllers/Api/EmployeeApiController.php
+++ b/app/Controllers/Api/EmployeeApiController.php
@@ -43,7 +43,7 @@ class EmployeeApiController extends BaseApiController
     {
         try {
             $data = [
-                'departments' => $this->organizationService->getFormattedDepartmentListForAll(),
+                'departments' => $this->organizationService->getFormattedDepartmentListWithHierarchy(),
                 'positions' => $this->positionRepository->getAll(),
             ];
             $this->apiSuccess($data);


### PR DESCRIPTION
- `EmployeeApiController`의 `getInitialData` 메소드에서 `OrganizationService`의 `getFormattedDepartmentListForAll()`을 호출하던 부분을 새로운 메소드 이름인 `getFormattedDepartmentListWithHierarchy()`로 변경했습니다.
- 이전에 `OrganizationService`의 메소드 이름을 변경하면서 해당 메소드를 호출하던 다른 컨트롤러의 코드를 수정하지 않아 발생했던 'Call to undefined method' 오류를 해결했습니다.