### PR TITLE
Fix: Implement fullstack department filter for employee linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@
 ## [1.0.3 - 2025-10-26]
 
 ### 🐛 버그 수정 (Bug Fixes)
-- **사용자 관리의 직원 연결 필터 기능 수정**:
+- **사용자 관리의 직원 연결 필터 기능 수정 (Fullstack)**:
   - **문제**: `/admin/users` 페이지에서 직원을 연결할 때 부서 필터가 작동하지 않아 다른 부서의 직원들이 목록에 포함되는 문제.
-  - **원인**: `users.js`에서 부서 필터의 `change` 이벤트가 발생했을 때, `loadUnlinkedEmployees()` 함수를 호출하면서 선택된 부서 ID를 전달하지 않았음.
-  - **수정**: `departmentFilter`의 이벤트 리스너에서 `e.target.value`를 `loadUnlinkedEmployees()` 함수로 전달하도록 수정하여, API 요청 시 `department_id` 쿼리 파라미터가 포함되도록 함.
-  - **영향 범위**: `public/assets/js/pages/users.js`
-  - **함께 수정된 파일**: 없음
+  - **원인**: 1) 프론트엔드 `users.js`에서 API 요청 시 `department_id`를 보내지 않았고, 2) 백엔드 API에서 해당 파라미터를 처리하는 로직이 누락되었음.
+  - **수정**:
+    - **Frontend**: `users.js`의 `departmentFilter` 이벤트 리스너가 선택된 부서 ID를 `loadUnlinkedEmployees()` 함수로 전달하도록 수정.
+    - **Backend**: `EmployeeApiController`, `EmployeeService`, `EmployeeRepository`를 모두 수정하여 `department_id` 파라미터를 받아 SQL 쿼리에서 필터링하도록 로직 추가.
+  - **영향 범위**: `public/assets/js/pages/users.js`, `app/Controllers/Api/EmployeeApiController.php`, `app/Services/EmployeeService.php`, `app/Repositories/EmployeeRepository.php`
+  - **함께 수정된 파일**: 상기 영향 범위와 동일
 
 ## [1.0.2 - 2025-10-26]
 

--- a/app/Controllers/Api/EmployeeApiController.php
+++ b/app/Controllers/Api/EmployeeApiController.php
@@ -137,7 +137,8 @@ class EmployeeApiController extends BaseApiController
     public function unlinked(): void
     {
         try {
-            $unlinkedEmployees = $this->employeeService->getUnlinkedEmployees();
+            $departmentId = $this->request->get('department_id', null, 'int');
+            $unlinkedEmployees = $this->employeeService->getUnlinkedEmployees($departmentId);
             $this->apiSuccess($unlinkedEmployees);
         } catch (Exception $e) {
             $this->handleException($e);

--- a/app/Repositories/EmployeeRepository.php
+++ b/app/Repositories/EmployeeRepository.php
@@ -29,15 +29,22 @@ class EmployeeRepository {
      * 사용자 계정에 연결되지 않은 활성 직원을 찾습니다.
      * @return array
      */
-    public function findUnlinked(): array
+    public function findUnlinked(?int $departmentId = null): array
     {
+        $params = [];
         $sql = "SELECT e.*, p.level
                 FROM hr_employees e
                 LEFT JOIN sys_users u ON e.id = u.employee_id
                 LEFT JOIN hr_positions p ON e.position_id = p.id
-                WHERE u.employee_id IS NULL AND e.termination_date IS NULL
-                ORDER BY p.level ASC, e.hire_date ASC";
-        return $this->db->query($sql);
+                WHERE u.employee_id IS NULL AND e.termination_date IS NULL";
+
+        if ($departmentId) {
+            $sql .= " AND e.department_id = :department_id";
+            $params[':department_id'] = $departmentId;
+        }
+
+        $sql .= " ORDER BY p.level ASC, e.hire_date ASC";
+        return $this->db->query($sql, $params);
     }
 
     /**

--- a/app/Services/EmployeeService.php
+++ b/app/Services/EmployeeService.php
@@ -43,9 +43,9 @@ class EmployeeService
      * 사용자 계정에 연결되지 않은 직원을 가져옵니다.
      * @return array
      */
-    public function getUnlinkedEmployees(): array
+    public function getUnlinkedEmployees(?int $departmentId = null): array
     {
-        return $this->employeeRepository->findUnlinked();
+        return $this->employeeRepository->findUnlinked($departmentId);
     }
 
     /**


### PR DESCRIPTION
This commit provides a complete fix for the non-functional department filter on the user-employee linking modal in the admin panel.

The original bug was two-fold:
1.  The frontend JavaScript did not send the selected department ID to the API.
2.  The backend API was not equipped to receive or process a department ID to filter the results.

This patch addresses both issues:
- **Frontend (`users.js`):** The `change` event listener on the department filter now correctly passes the selected department ID to the `loadUnlinkedEmployees` function.
- **Backend (`EmployeeApiController`, `EmployeeService`, `EmployeeRepository`):** The entire stack has been updated to handle the `department_id` query parameter. The controller now reads the value, the service passes it down, and the repository modifies the SQL query to filter the unlinked employees by the specified department.