### PR TITLE
Refactor: Split waste.manage_admin permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@
 ## [1.0.5 - 2025-10-26]
 
 ### ♻️ 리팩토링 (Refactoring)
-- **`waste.manage_admin` 권한 리팩토링**:
-  - **변경 이유**: 권한의 역할을 명확히 하고 단일 책임을 갖도록 하기 위함.
-  - **변경 내용**: 기존의 포괄적인 `waste.manage_admin` 권한을 `waste.manage_online`으로 대체. 이 새로운 권한은 인터넷 배출 신고 관리와 관련된 모든 관리자급 기능을 제어.
+- **`waste.manage_admin` 권한 분리 및 이름 변경**:
+  - **변경 이유**: 단일 책임 원칙에 따라, 하나의 권한이 너무 많은 책임을 갖는 것을 방지하고 역할 분리를 명확히 하기 위함.
+  - **변경 내용**: 기존의 `waste.manage_admin` 권한을 다음과 같이 두 개의 구체적인 권한으로 분리하고 최종적으로 이름을 확정:
+    - `waste.process`: 현장 등록 및 수거 처리 관련 기능(개별 처리)을 제어.
+    - `waste.manage`: 인터넷 배출 신고 관리 기능(조회, 수정, 삭제, 일괄 등록)을 제어.
   - **영향 범위**: `database/seeds/04_permissions.sql`, `database/seeds/09_menus.sql`, `routes/web.php`, `routes/api.php`
   - **함께 수정된 파일**: 상기 영향 범위와 동일.
 

--- a/database/seeds/04_permissions.sql
+++ b/database/seeds/04_permissions.sql
@@ -17,7 +17,6 @@ INSERT INTO `sys_permissions` (`id`, `key`, `description`) VALUES
 (23, 'leave.approve', '휴가 신청 승인/거부'),
 (24, 'leave.manage_entitlement', '연차 부여 및 수동 조정'),
 
--- Littering Management (6)
 -- Littering Management (7)
 (30, 'littering.view', '부적정배출 현황 조회'),
 (31, 'littering.create', '부적정배출 신규 등록'),
@@ -30,9 +29,9 @@ INSERT INTO `sys_permissions` (`id`, `key`, `description`) VALUES
 
 -- Waste Collection Management (2)
 -- Waste Collection Management (3)
--- Waste Collection Management (2)
 (40, 'waste.view', '대형폐기물 수거 현황 조회'),
-(41, 'waste.manage_online', '대형폐기물 인터넷배출 관리'),
+(41, 'waste.process', '대형폐기물 현장등록 수거처리'),
+(42, 'waste.manage', '대형폐기물 인터넷배출 관리'),
 
 -- User Management (3)
 (50, 'user.view', '사용자 계정 목록 조회'),

--- a/database/seeds/09_menus.sql
+++ b/database/seeds/09_menus.sql
@@ -3,7 +3,7 @@ INSERT INTO `sys_menus` (`id`, `parent_id`, `name`, `url`, `icon`, `permission_k
 (200, NULL, '운행노선', '#', 'ri-route-line', '', 20),
 (300, NULL, '대형폐기물', '/waste/index', 'ri-truck-line', 'waste.view', 30),
 (301, 300, '대형폐기물 수거', '/waste/index', 'ri-truck-line', 'waste.view', 10),
-(302, 300, '인터넷배출 관리', '/waste/manage', 'ri-global-line', 'waste.manage_online', 20),
+(302, 300, '인터넷배출 관리', '/waste/manage', 'ri-global-line', 'waste.manage', 20),
 (400, NULL, '무단투기 관리', '/littering/manage', 'ri-map-pin-user-line', 'littering.view', 40),
 (401, 400, '무단투기 신고/처리', '/littering/index', 'ri-map-pin-add-line', 'littering.process', 10),
 (402, 400, '검토 및 승인', '/littering/manage', 'ri-user-shared-line', 'littering.confirm', 20),

--- a/routes/api.php
+++ b/routes/api.php
@@ -117,11 +117,11 @@ $router->post('/littering_admin/reports/{id}/approve', [LitteringAdminApiControl
     // Waste Collection API routes
     $router->get('/waste-collections', [WasteCollectionApiController::class, 'index'])->name('api.waste-collections.index')->middleware('auth')->middleware('permission', 'waste.view');
     $router->post('/waste-collections', [WasteCollectionApiController::class, 'store'])->name('api.waste-collections.store')->middleware('auth')->middleware('permission', 'waste.view');
-    $router->get('/waste-collections/admin', [WasteCollectionApiController::class, 'getAdminCollections'])->name('api.waste-collections.admin')->middleware('auth')->middleware('permission', 'waste.manage_online');
-    $router->post('/waste-collections/admin/{id}/process', [WasteCollectionApiController::class, 'processCollection'])->name('api.waste-collections.process')->middleware('auth')->middleware('permission', 'waste.manage_online');
-    $router->put('/waste-collections/admin/{id}/items', [WasteCollectionApiController::class, 'updateItems'])->name('api.waste-collections.items')->middleware('auth')->middleware('permission', 'waste.manage_online');
-    $router->put('/waste-collections/admin/{id}/memo', [WasteCollectionApiController::class, 'updateMemo'])->name('api.waste-collections.memo')->middleware('auth')->middleware('permission', 'waste.manage_online');
-    $router->post('/waste-collections/admin/parse-html', [WasteCollectionApiController::class, 'parseHtmlFile'])->name('api.waste-collections.parse-html')->middleware('auth')->middleware('permission', 'waste.manage_online');
-    $router->post('/waste-collections/admin/batch-register', [WasteCollectionApiController::class, 'batchRegister'])->name('api.waste-collections.batch-register')->middleware('auth')->middleware('permission', 'waste.manage_online');
-    $router->delete('/waste-collections/admin/online-submissions', [WasteCollectionApiController::class, 'clearOnlineSubmissions'])->name('api.waste-collections.clear-online')->middleware('auth')->middleware('permission', 'waste.manage_online');
+    $router->get('/waste-collections/admin', [WasteCollectionApiController::class, 'getAdminCollections'])->name('api.waste-collections.admin')->middleware('auth')->middleware('permission', 'waste.manage');
+    $router->post('/waste-collections/admin/{id}/process', [WasteCollectionApiController::class, 'processCollection'])->name('api.waste-collections.process')->middleware('auth')->middleware('permission', 'waste.process');
+    $router->put('/waste-collections/admin/{id}/items', [WasteCollectionApiController::class, 'updateItems'])->name('api.waste-collections.items')->middleware('auth')->middleware('permission', 'waste.manage');
+    $router->put('/waste-collections/admin/{id}/memo', [WasteCollectionApiController::class, 'updateMemo'])->name('api.waste-collections.memo')->middleware('auth')->middleware('permission', 'waste.manage');
+    $router->post('/waste-collections/admin/parse-html', [WasteCollectionApiController::class, 'parseHtmlFile'])->name('api.waste-collections.parse-html')->middleware('auth')->middleware('permission', 'waste.manage');
+    $router->post('/waste-collections/admin/batch-register', [WasteCollectionApiController::class, 'batchRegister'])->name('api.waste-collections.batch-register')->middleware('auth')->middleware('permission', 'waste.manage');
+    $router->delete('/waste-collections/admin/online-submissions', [WasteCollectionApiController::class, 'clearOnlineSubmissions'])->name('api.waste-collections.clear-online')->middleware('auth')->middleware('permission', 'waste.manage');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -53,7 +53,7 @@ $router->get('/littering/edit', [LitteringController::class, 'edit'])->name('lit
 
 // --- 폐기물 수거 ---
 $router->get('/waste/index', [WasteCollectionController::class, 'index'])->name('waste.index')->middleware('auth')->middleware('permission', 'waste.view');
-$router->get('/waste/manage', [WasteCollectionController::class, 'manage'])->name('waste.manage')->middleware('auth')->middleware('permission', 'waste.manage_online');
+$router->get('/waste/manage', [WasteCollectionController::class, 'manage'])->name('waste.manage')->middleware('auth')->middleware('permission', 'waste.manage');
 
 // --- 관리자 ---
 $router->get('/admin/organization', [AdminController::class, 'organization'])->name('admin.organization')->middleware('auth')->middleware('permission', 'organization.manage');


### PR DESCRIPTION
This commit refactors the waste management permissions to provide more granular control and adhere to the principle of single responsibility.

The overly broad `waste.manage_admin` permission has been removed and replaced with two new, more specific permissions:
-   `waste.process`: Controls access to on-site collection processing features.
-   `waste.manage`: Controls access to features for managing online waste submissions.

This change has been applied consistently across the application:
-   **Database Seeds:** The `sys_permissions` and `sys_menus` tables have been updated to reflect the new permission structure.
-   **Routing:** All relevant web and API routes (`routes/web.php`, `routes/api.php`) have been updated to use the new, more specific permissions.

This refactoring improves the clarity, security, and maintainability of the permission system.