### PR TITLE
feat: 사이트 전체 활동 로깅 기능 추가 및 개선

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 이 문서는 프로젝트의 주요 변경 사항, 특히 기존 코드베이스에 영향을 줄 수 있는 중요한 수정 내역을 기록합니다. 모든 개발 에이전트는 코드 변경 시 이 문서를 참조하고, 자신의 변경 사항을 아래 형식에 맞게 기록해야 합니다.
 
 ---
+## [1.4.5 - 2025-10-28]
+
+### ✨ 새로운 기능 (Features)
+- **사이트 전체 활동 로깅 기능 추가**:
+  - **설명**: 모든 사용자의 사이트 이용 행위(페이지 접근, API 호출)를 추적하고 감사할 수 있도록 `sys_activity_logs` 테이블에 기록하는 기능을 구현했습니다.
+  - **변경 내용**:
+    - `ActivityLogger` 서비스를 확장하여 페이지 접근(`logPageAccess`) 및 API 호출(`logApiCall`)을 기록하는 메서드를 추가했습니다.
+    - `Web/BaseController`와 `Api/BaseApiController`의 생성자에서 `ActivityLogger`를 호출하여, 모든 웹 페이지 요청과 API 호출이 자동으로 기록되도록 수정했습니다.
+    - 로그인, 정적 에셋(.js, .css) 등 불필요한 요청은 로그 대상에서 제외하여 효율성을 높였습니다.
+  - **영향 범위**: `app/Services/ActivityLogger.php`, `app/Controllers/Web/BaseController.php`, `app/Controllers/Api/BaseApiController.php`
+
+### ♻️ 리팩토링 (Refactoring)
+- **활동 로그 중복 제거**:
+  - **변경 이유**: '메뉴 접근' 로그와 '페이지 접근' 로그가 중복으로 기록되는 문제를 해결하고 코드를 단순화했습니다.
+  - **변경 내용**:
+    - `ViewDataService`에서 `logMenuAccess` 메서드 호출을 제거했습니다.
+    - `ActivityLogger` 서비스에서 더 이상 사용되지 않는 `logMenuAccess` 메서드를 삭제하여 `logPageAccess`로 로깅을 일원화했습니다.
+  - **영향 범위**: `app/Services/ViewDataService.php`, `app/Services/ActivityLogger.php`
+
 ## [1.4.4 - 2025-10-28]
 
 ### ♻️ 리팩토링 (Refactoring)

--- a/app/Controllers/Api/BaseApiController.php
+++ b/app/Controllers/Api/BaseApiController.php
@@ -40,6 +40,19 @@ abstract class BaseApiController extends BaseController
     }
 
     /**
+     * API 요청을 기록하기 위해 부모 메서드를 오버라이드합니다.
+     */
+    protected function logRequest(): void
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'UNKNOWN';
+        $uri = $_SERVER['REQUEST_URI'] ?? '/';
+        $body = file_get_contents('php://input');
+
+        $this->activityLogger->logApiCall($method, $uri, $body);
+    }
+
+
+    /**
      * 요청이 AJAX 요청인지 확인합니다
      */
     protected function isAjaxRequest(): bool

--- a/app/Controllers/Web/BaseController.php
+++ b/app/Controllers/Web/BaseController.php
@@ -25,6 +25,31 @@ abstract class BaseController
         $this->authService = $authService;
         $this->viewDataService = $viewDataService;
         $this->activityLogger = $activityLogger;
+
+        $this->logRequest();
+    }
+
+    /**
+     * 요청을 기록합니다.
+     */
+    protected function logRequest(): void
+    {
+        $uri = $_SERVER['REQUEST_URI'] ?? '/';
+
+        // 특정 URI 패턴은 로그에서 제외
+        $excludedPatterns = [
+            '/login',
+            '/auth/kakao/callback',
+            '/assets/'
+        ];
+
+        foreach ($excludedPatterns as $pattern) {
+            if (str_starts_with($uri, $pattern)) {
+                return;
+            }
+        }
+
+        $this->activityLogger->logPageAccess($uri);
     }
 
     /**

--- a/app/Services/ViewDataService.php
+++ b/app/Services/ViewDataService.php
@@ -46,9 +46,6 @@ class ViewDataService
 
         // 활성 메뉴를 찾아 페이지 제목을 결정합니다.
         $pageTitle = $this->findActiveMenuName($allMenus);
-        if ($pageTitle) {
-            $this->activityLogger->logMenuAccess($pageTitle);
-        }
 
         // 플래시 메시지를 가져와 데이터 배열에 추가합니다.
         $flashSuccess = $this->sessionManager->getFlash('success');


### PR DESCRIPTION
사용자 활동 추적 및 감사를 위해 모든 페이지 접근과 API 호출을 기록하는 기능을 구현하고, 중복되는 로그를 제거하여 코드를 개선했습니다.

- `ActivityLogger`에 `logPageAccess`와 `logApiCall` 메서드를 추가하고, `BaseController`와 `BaseApiController`에서 각각의 요청 유형에 맞게 로깅 메서드를 호출하도록 수정했습니다.
- 불필요한 로그가 쌓이지 않도록 로그인 페이지, asset 파일 등의 요청은 제외했습니다.
- 기존의 중복되던 '메뉴 접근' 로그를 제거하고 '페이지 접근' 로그로 일원화하여 코드를 정리했습니다.