### PR TITLE
fix(api): `supply/purchases` API 라우팅 충돌 해결

### DIFF
--- a/public/assets/js/pages/supply-budget-summary.js
+++ b/public/assets/js/pages/supply-budget-summary.js
@@ -5,7 +5,7 @@
 class SupplyBudgetSummaryPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/plans'
+            API_URL: '/supply/plans'
         });
         
         this.charts = {};
@@ -257,7 +257,7 @@ class SupplyBudgetSummaryPage extends BasePage {
     exportBudget() {
         const yearSelector = document.getElementById('year-selector');
         const year = yearSelector ? yearSelector.value : new Date().getFullYear();
-        window.open(`${this.config.apiBaseUrl}/export-budget?year=${year}`, '_blank');
+        window.open(`${this.config.API_URL}/export-budget?year=${year}`, '_blank');
     }
 }
 

--- a/public/assets/js/pages/supply-categories-create.js
+++ b/public/assets/js/pages/supply-categories-create.js
@@ -5,7 +5,7 @@
 class SupplyCategoryCreatePage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/categories'
+            API_URL: '/supply/categories'
         });
         
         this.mainCategories = [];
@@ -36,7 +36,7 @@ class SupplyCategoryCreatePage extends BasePage {
 
     async loadMainCategories() {
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}/level/1`);
+            const data = await this.apiCall(`${this.config.API_URL}/level/1`);
             this.mainCategories = data.data || [];
             this.renderParentOptions();
         } catch (error) {
@@ -90,7 +90,7 @@ class SupplyCategoryCreatePage extends BasePage {
         }
         
         try {
-            const url = `${this.config.apiBaseUrl}/generate-code?level=${level}${parentId ? `&parent_id=${parentId}` : ''}`;
+            const url = `${this.config.API_URL}/generate-code?level=${level}${parentId ? `&parent_id=${parentId}` : ''}`;
             const data = await this.apiCall(url);
             document.getElementById('category-code').value = data.data.code;
         } catch (error) {
@@ -115,7 +115,7 @@ class SupplyCategoryCreatePage extends BasePage {
         const data = Object.fromEntries(formData.entries());
 
         try {
-            const result = await this.apiCall(this.config.apiBaseUrl, {
+            const result = await this.apiCall(this.config.API_URL, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/public/assets/js/pages/supply-categories-edit.js
+++ b/public/assets/js/pages/supply-categories-edit.js
@@ -5,7 +5,7 @@
 class SupplyCategoryEditPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/categories'
+            API_URL: '/supply/categories'
         });
         
         // From the global scope, injected by the controller
@@ -25,7 +25,7 @@ class SupplyCategoryEditPage extends BasePage {
         }
 
         try {
-            const response = await this.apiCall(`${this.config.apiBaseUrl}/${this.categoryId}`);
+            const response = await this.apiCall(`${this.config.API_URL}/${this.categoryId}`);
             this.categoryData = response.data;
             this.renderForm();
             this.renderInfo();
@@ -165,7 +165,7 @@ class SupplyCategoryEditPage extends BasePage {
         };
 
         try {
-            await this.apiCall(`${this.config.apiBaseUrl}/${this.categoryId}`, {
+            await this.apiCall(`${this.config.API_URL}/${this.categoryId}`, {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(data)

--- a/public/assets/js/pages/supply-categories-show.js
+++ b/public/assets/js/pages/supply-categories-show.js
@@ -5,7 +5,7 @@
 class SupplyCategoryShowPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/categories'
+            API_URL: '/supply/categories'
         });
         
         this.categoryId = window.viewData?.categoryId || null;
@@ -24,7 +24,7 @@ class SupplyCategoryShowPage extends BasePage {
         }
 
         try {
-            const response = await this.apiCall(`${this.config.apiBaseUrl}/${this.categoryId}`);
+            const response = await this.apiCall(`${this.config.API_URL}/${this.categoryId}`);
             this.categoryData = response.data;
 
             document.getElementById('loading-container').style.display = 'none';
@@ -195,7 +195,7 @@ class SupplyCategoryShowPage extends BasePage {
 
         if (result.isConfirmed) {
             try {
-                await this.apiCall(`${this.config.apiBaseUrl}/${this.categoryId}/toggle-status`, { method: 'PUT' });
+                await this.apiCall(`${this.config.API_URL}/${this.categoryId}/toggle-status`, { method: 'PUT' });
                 Toast.success('상태가 변경되었습니다.');
                 this.loadInitialData(); // Reload data to show updated status
             } catch (error) {

--- a/public/assets/js/pages/supply-categories.js
+++ b/public/assets/js/pages/supply-categories.js
@@ -5,7 +5,7 @@
 class SupplyCategoryPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/categories'
+            API_URL: '/supply/categories'
         });
         
         this.categories = [];
@@ -62,7 +62,7 @@ class SupplyCategoryPage extends BasePage {
 
     async loadCategories() {
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}?hierarchical=true`);
+            const data = await this.apiCall(`${this.config.API_URL}?hierarchical=true`);
             this.categories = data.data || [];
             this.filteredCategories = [...this.categories];
             this.renderCategoryList();
@@ -196,7 +196,7 @@ class SupplyCategoryPage extends BasePage {
 
     async showCategoryDetails(categoryId) {
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}/${categoryId}`);
+            const data = await this.apiCall(`${this.config.API_URL}/${categoryId}`);
             const category = data.data;
             this.renderCategoryDetails(category);
         } catch (error) {
@@ -347,7 +347,7 @@ class SupplyCategoryPage extends BasePage {
 
     async loadParentCategoryOptions() {
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}/level/1`);
+            const data = await this.apiCall(`${this.config.API_URL}/level/1`);
             const mainCategories = data.data || [];
             
             const select = document.getElementById('parent-category');
@@ -395,7 +395,7 @@ class SupplyCategoryPage extends BasePage {
         }
         
         try {
-            const url = `${this.config.apiBaseUrl}/generate-code?level=${level}${parentId ? `&parent_id=${parentId}` : ''}`;
+            const url = `${this.config.API_URL}/generate-code?level=${level}${parentId ? `&parent_id=${parentId}` : ''}`;
             const data = await this.apiCall(url);
             document.getElementById('category-code').value = data.data.code;
         } catch (error) {
@@ -415,8 +415,8 @@ class SupplyCategoryPage extends BasePage {
         
         try {
             const url = this.isEditMode ? 
-                `${this.config.apiBaseUrl}/${this.selectedCategoryId}` : 
-                this.config.apiBaseUrl;
+                `${this.config.API_URL}/${this.selectedCategoryId}` :
+                this.config.API_URL;
             
             const method = this.isEditMode ? 'PUT' : 'POST';
             
@@ -494,7 +494,7 @@ class SupplyCategoryPage extends BasePage {
         if (!result.isConfirmed) return;
         
         try {
-            const response = await this.apiCall(`${this.config.apiBaseUrl}/${categoryId}/toggle-status`, {
+            const response = await this.apiCall(`${this.config.API_URL}/${categoryId}/toggle-status`, {
                 method: 'PUT'
             });
             
@@ -534,7 +534,7 @@ class SupplyCategoryPage extends BasePage {
         if (!this.selectedCategoryId) return;
         
         try {
-            await this.apiCall(`${this.config.apiBaseUrl}/${this.selectedCategoryId}`, {
+            await this.apiCall(`${this.config.API_URL}/${this.selectedCategoryId}`, {
                 method: 'DELETE'
             });
 

--- a/public/assets/js/pages/supply-dashboard.js
+++ b/public/assets/js/pages/supply-dashboard.js
@@ -5,7 +5,7 @@
 class SupplyDashboardPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply'
+            API_URL: '/supply'
         });
     }
 
@@ -37,7 +37,7 @@ class SupplyDashboardPage extends BasePage {
     async loadDashboardStats() {
         try {
             // 필요시 API를 통해 통계 데이터 로드
-            // const stats = await this.apiCall(`${this.config.apiBaseUrl}/dashboard-stats`);
+            // const stats = await this.apiCall(`${this.config.API_URL}/dashboard-stats`);
             // this.renderStats(stats);
         } catch (error) {
             console.error('Error loading dashboard stats:', error);

--- a/public/assets/js/pages/supply-distributions-create.js
+++ b/public/assets/js/pages/supply-distributions-create.js
@@ -5,7 +5,7 @@
 class SupplyDistributionsCreatePage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/distributions'
+            API_URL: '/supply/distributions'
         });
         
         this.availableItems = [];
@@ -42,7 +42,7 @@ class SupplyDistributionsCreatePage extends BasePage {
     async loadAvailableItems() {
         const itemSelect = document.getElementById('item-id');
         try {
-            const response = await this.apiCall(`${this.config.apiBaseUrl}/available-items`);
+            const response = await this.apiCall(`${this.config.API_URL}/available-items`);
             this.availableItems = response.data || [];
             this.renderOptions(itemSelect, this.availableItems, {
                 value: 'id',
@@ -61,7 +61,7 @@ class SupplyDistributionsCreatePage extends BasePage {
     async loadDepartments() {
         const deptSelect = document.getElementById('department-id');
         try {
-            const response = await this.apiCall(`${this.config.apiBaseUrl}/departments`);
+            const response = await this.apiCall(`${this.config.API_URL}/departments`);
             this.departments = response.data || [];
             this.renderOptions(deptSelect, this.departments, {
                 value: 'id',
@@ -87,7 +87,7 @@ class SupplyDistributionsCreatePage extends BasePage {
         employeeSelect.disabled = true;
 
         try {
-            const response = await this.apiCall(`${this.config.apiBaseUrl}/employees-by-department/${departmentId}`);
+            const response = await this.apiCall(`${this.config.API_URL}/employees-by-department/${departmentId}`);
             this.employees = response.data || [];
             this.renderOptions(employeeSelect, this.employees, {
                 value: 'id',
@@ -153,7 +153,7 @@ class SupplyDistributionsCreatePage extends BasePage {
         const data = Object.fromEntries(formData.entries());
         
         try {
-            await this.apiCall(this.config.apiBaseUrl, {
+            await this.apiCall(this.config.API_URL, {
                 method: 'POST',
                 body: JSON.stringify(data)
             });

--- a/public/assets/js/pages/supply-distributions-edit.js
+++ b/public/assets/js/pages/supply-distributions-edit.js
@@ -5,7 +5,7 @@
 class SupplyDistributionsEditPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/distributions'
+            API_URL: '/supply/distributions'
         });
         
         this.distributionId = document.getElementById('distribution-id')?.value || null;
@@ -38,7 +38,7 @@ class SupplyDistributionsEditPage extends BasePage {
         }
 
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}/${this.distributionId}`);
+            const data = await this.apiCall(`${this.config.API_URL}/${this.distributionId}`);
             this.distribution = data.data;
             this.originalQuantity = this.distribution.quantity;
             this.renderDistributionForm();
@@ -146,7 +146,7 @@ class SupplyDistributionsEditPage extends BasePage {
         };
 
         try {
-            const result = await this.apiCall(`${this.config.apiBaseUrl}/${this.distributionId}`, {
+            const result = await this.apiCall(`${this.config.API_URL}/${this.distributionId}`, {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json'

--- a/public/assets/js/pages/supply-items-create.js
+++ b/public/assets/js/pages/supply-items-create.js
@@ -5,7 +5,7 @@
 class SupplyItemCreatePage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/items'
+            API_URL: '/supply/items'
         });
     }
 
@@ -45,7 +45,7 @@ class SupplyItemCreatePage extends BasePage {
 
     async generateItemCode() {
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}/generate-code`);
+            const data = await this.apiCall(`${this.config.API_URL}/generate-code`);
             const codeInput = document.getElementById('item-code');
             if (codeInput && data.data?.code) {
                 codeInput.value = data.data.code;
@@ -77,7 +77,7 @@ class SupplyItemCreatePage extends BasePage {
                 is_active: document.getElementById('is-active').checked ? 1 : 0
             };
 
-            await this.apiCall(this.config.apiBaseUrl, {
+            await this.apiCall(this.config.API_URL, {
                 method: 'POST',
                 body: JSON.stringify(formData)
             });

--- a/public/assets/js/pages/supply-items-edit.js
+++ b/public/assets/js/pages/supply-items-edit.js
@@ -5,7 +5,7 @@
 class SupplyItemEditPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/items'
+            API_URL: '/supply/items'
         });
         
         this.itemId = document.getElementById('item-id')?.value;
@@ -45,7 +45,7 @@ class SupplyItemEditPage extends BasePage {
 
     async loadItemData() {
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}/${this.itemId}`);
+            const data = await this.apiCall(`${this.config.API_URL}/${this.itemId}`);
             const item = data.data;
             
             if (item) {
@@ -84,7 +84,7 @@ class SupplyItemEditPage extends BasePage {
                 is_active: document.getElementById('is-active').checked ? 1 : 0
             };
 
-            await this.apiCall(`${this.config.apiBaseUrl}/${this.itemId}`, {
+            await this.apiCall(`${this.config.API_URL}/${this.itemId}`, {
                 method: 'PUT',
                 body: JSON.stringify(formData)
             });

--- a/public/assets/js/pages/supply-items-show.js
+++ b/public/assets/js/pages/supply-items-show.js
@@ -5,7 +5,7 @@
 class SupplyItemShowPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/items'
+            API_URL: '/supply/items'
         });
         
         this.itemId = document.getElementById('item-id')?.value;
@@ -24,7 +24,7 @@ class SupplyItemShowPage extends BasePage {
 
     async loadItemDetails() {
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}/${this.itemId}`);
+            const data = await this.apiCall(`${this.config.API_URL}/${this.itemId}`);
             const item = data.data;
             
             const container = document.getElementById('item-details-container');

--- a/public/assets/js/pages/supply-items.js
+++ b/public/assets/js/pages/supply-items.js
@@ -5,7 +5,7 @@
 class SupplyItemsPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/items'
+            API_URL: '/supply/items'
         });
         
         this.dataTable = null;
@@ -15,15 +15,15 @@ class SupplyItemsPage extends BasePage {
     setupEventListeners() {
         // 필터 이벤트
         document.getElementById('filter-category')?.addEventListener('change', () => {
-            this.dataTable?.ajax.reload();
+            this.loadItems();
         });
 
         document.getElementById('filter-status')?.addEventListener('change', () => {
-            this.dataTable?.ajax.reload();
+            this.loadItems();
         });
 
         document.getElementById('search-input')?.addEventListener('keyup', () => {
-            this.dataTable?.search(document.getElementById('search-input').value).draw();
+            this.loadItems();
         });
 
         // 상태 변경 확인
@@ -40,6 +40,7 @@ class SupplyItemsPage extends BasePage {
     loadInitialData() {
         this.loadCategories();
         this.initializeDataTable();
+        this.loadItems(); // 데이터 로드
     }
 
     async loadCategories() {
@@ -61,24 +62,31 @@ class SupplyItemsPage extends BasePage {
         }
     }
 
+    async loadItems() {
+        try {
+            const params = {
+                category_id: document.getElementById('filter-category')?.value || '',
+                is_active: document.getElementById('filter-status')?.value || '',
+                search: document.getElementById('search-input')?.value || ''
+            };
+
+            const queryString = new URLSearchParams(params).toString();
+            const result = await this.apiCall(`${this.config.API_URL}?${queryString}`);
+
+            this.dataTable.clear().rows.add(result.data || []).draw();
+
+        } catch (error) {
+            console.error('Error loading items:', error);
+            Toast.error('품목을 불러오는 중 오류가 발생했습니다.');
+        }
+    }
+
     initializeDataTable() {
         const self = this;
         
         this.dataTable = $('#items-table').DataTable({
             processing: true,
-            serverSide: false,
-            ajax: {
-                url: this.config.apiBaseUrl,
-                type: 'GET',
-                data: function(d) {
-                    return {
-                        category_id: document.getElementById('filter-category')?.value || '',
-                        is_active: document.getElementById('filter-status')?.value || '',
-                        search: document.getElementById('search-input')?.value || ''
-                    };
-                },
-                dataSrc: 'data'
-            },
+            serverSide: false, // 데이터를 서버에서 가져오지만, DataTable의 serverSide 기능은 사용 안함
             columns: [
                 { data: 'item_code' },
                 { data: 'item_name' },
@@ -125,7 +133,8 @@ class SupplyItemsPage extends BasePage {
                 url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json'
             },
             order: [[0, 'asc']],
-            pageLength: 25
+            pageLength: 25,
+            searching: false // DataTable 자체 검색 기능 비활성화
         });
 
         // 이벤트 위임
@@ -154,12 +163,12 @@ class SupplyItemsPage extends BasePage {
 
     async confirmStatusChange() {
         try {
-            await this.apiCall(`${this.config.apiBaseUrl}/${this.currentItemId}/toggle-status`, {
+            await this.apiCall(`${this.config.API_URL}/${this.currentItemId}/toggle-status`, {
                 method: 'PUT'
             });
             
             Toast.success('품목 상태가 변경되었습니다.');
-            this.dataTable.ajax.reload();
+            this.loadItems();
             
             const modal = bootstrap.Modal.getInstance(document.getElementById('statusModal'));
             modal.hide();
@@ -179,12 +188,12 @@ class SupplyItemsPage extends BasePage {
 
     async confirmDelete() {
         try {
-            await this.apiCall(`${this.config.apiBaseUrl}/${this.currentItemId}`, {
+            await this.apiCall(`${this.config.API_URL}/${this.currentItemId}`, {
                 method: 'DELETE'
             });
             
             Toast.success('품목이 삭제되었습니다.');
-            this.dataTable.ajax.reload();
+            this.loadItems();
             
             const modal = bootstrap.Modal.getInstance(document.getElementById('deleteModal'));
             modal.hide();

--- a/public/assets/js/pages/supply-plans-copy.js
+++ b/public/assets/js/pages/supply-plans-copy.js
@@ -5,7 +5,7 @@
 class SupplyPlansCopyPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/plans'
+            API_URL: '/supply/plans'
         });
 
         this.sourceYear = new Date().getFullYear() - 1;
@@ -39,8 +39,8 @@ class SupplyPlansCopyPage extends BasePage {
         this.showLoading();
         try {
             const [sourceResponse, targetResponse] = await Promise.all([
-                this.apiCall(`${this.config.apiBaseUrl}?year=${this.sourceYear}`),
-                this.apiCall(`${this.config.apiBaseUrl}?year=${this.targetYear}`)
+                this.apiCall(`${this.config.API_URL}?year=${this.sourceYear}`),
+                this.apiCall(`${this.config.API_URL}?year=${this.targetYear}`)
             ]);
 
             this.sourcePlans = sourceResponse.data || [];
@@ -124,7 +124,7 @@ class SupplyPlansCopyPage extends BasePage {
         this.setButtonLoading('#copy-plans-btn', '복사 중...');
 
         try {
-            const response = await this.apiCall(`${this.config.apiBaseUrl}/copy`, {
+            const response = await this.apiCall(`${this.config.API_URL}/copy`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/public/assets/js/pages/supply-plans-create.js
+++ b/public/assets/js/pages/supply-plans-create.js
@@ -5,7 +5,7 @@
 class SupplyPlansCreatePage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/plans'
+            API_URL: '/supply/plans'
         });
         
         this.year = window.supplyPlanCreateData?.year || new Date().getFullYear();
@@ -178,7 +178,7 @@ class SupplyPlansCreatePage extends BasePage {
         };
 
         try {
-            const result = await this.apiCall(this.config.apiBaseUrl, {
+            const result = await this.apiCall(this.config.API_URL, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/public/assets/js/pages/supply-plans-edit.js
+++ b/public/assets/js/pages/supply-plans-edit.js
@@ -5,7 +5,7 @@
 class SupplyPlansEditPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/plans'
+            API_URL: '/supply/plans'
         });
         
         this.planId = window.supplyPlanEditData?.planId || null;
@@ -45,7 +45,7 @@ class SupplyPlansEditPage extends BasePage {
         }
 
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}/${this.planId}`);
+            const data = await this.apiCall(`${this.config.API_URL}/${this.planId}`);
             this.originalData = data.data;
             this.renderPlanForm();
         } catch (error) {
@@ -182,7 +182,7 @@ class SupplyPlansEditPage extends BasePage {
         };
 
         try {
-            const result = await this.apiCall(`${this.config.apiBaseUrl}/${this.planId}`, {
+            const result = await this.apiCall(`${this.config.API_URL}/${this.planId}`, {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json'

--- a/public/assets/js/pages/supply-purchases-create.js
+++ b/public/assets/js/pages/supply-purchases-create.js
@@ -5,7 +5,7 @@
 class SupplyPurchasesCreatePage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/purchases'
+            API_URL: '/supply/purchases'
         });
         
         this.items = [];
@@ -120,7 +120,7 @@ class SupplyPurchasesCreatePage extends BasePage {
         };
 
         try {
-            const result = await this.apiCall(this.config.apiBaseUrl, {
+            const result = await this.apiCall(this.config.API_URL, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/public/assets/js/pages/supply-purchases-edit.js
+++ b/public/assets/js/pages/supply-purchases-edit.js
@@ -5,7 +5,7 @@
 class SupplyPurchasesEditPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/purchases'
+            API_URL: '/supply/purchases'
         });
         
         this.purchaseId = window.purchaseEditData?.purchaseId || null;
@@ -40,7 +40,7 @@ class SupplyPurchasesEditPage extends BasePage {
         }
 
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}/${this.purchaseId}`);
+            const data = await this.apiCall(`${this.config.API_URL}/${this.purchaseId}`);
             this.purchase = data.data;
             this.item = this.purchase.item;
             this.renderPurchaseForm();
@@ -112,7 +112,7 @@ class SupplyPurchasesEditPage extends BasePage {
         };
 
         try {
-            const result = await this.apiCall(`${this.config.apiBaseUrl}/${this.purchaseId}`, {
+            const result = await this.apiCall(`${this.config.API_URL}/${this.purchaseId}`, {
                 method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json'

--- a/public/assets/js/pages/supply-purchases-receive.js
+++ b/public/assets/js/pages/supply-purchases-receive.js
@@ -5,7 +5,7 @@
 class SupplyPurchasesReceivePage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/purchases'
+            API_URL: '/supply/purchases'
         });
         
         this.pendingPurchases = [];
@@ -33,7 +33,7 @@ class SupplyPurchasesReceivePage extends BasePage {
 
     async loadPendingPurchases() {
         try {
-            const data = await this.apiCall(`${this.config.apiBaseUrl}?status=pending`);
+            const data = await this.apiCall(`${this.config.API_URL}?status=pending`);
             this.pendingPurchases = data.data || [];
             this.renderPendingPurchases();
         } catch (error) {
@@ -222,7 +222,7 @@ class SupplyPurchasesReceivePage extends BasePage {
         try {
             if (this.isBulkReceive) {
                 // 일괄 입고 처리
-                const result = await this.apiCall(`${this.config.apiBaseUrl}/bulk-receive`, {
+                const result = await this.apiCall(`${this.config.API_URL}/bulk-receive`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
@@ -245,7 +245,7 @@ class SupplyPurchasesReceivePage extends BasePage {
                 }
             } else {
                 // 개별 입고 처리
-                const result = await this.apiCall(`${this.config.apiBaseUrl}/${this.currentPurchaseIds[0]}/mark-received`, {
+                const result = await this.apiCall(`${this.config.API_URL}/${this.currentPurchaseIds[0]}/mark-received`, {
                     method: 'PATCH',
                     headers: {
                         'Content-Type': 'application/json'

--- a/public/assets/js/pages/supply-purchases.js
+++ b/public/assets/js/pages/supply-purchases.js
@@ -5,9 +5,10 @@
 class SupplyPurchasesPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/purchases'
+            API_URL: '/supply/purchases'
         });
         
+        this.dataTable = null;
         this.currentReceivePurchaseId = null;
         this.currentDeletePurchaseId = null;
         this.receivePurchaseModal = null;
@@ -15,96 +16,87 @@ class SupplyPurchasesPage extends BasePage {
     }
 
     setupEventListeners() {
-        // 입고 처리 버튼
-        document.querySelectorAll('.receive-purchase-btn').forEach(btn => {
-            btn.addEventListener('click', () => {
-                this.currentReceivePurchaseId = btn.dataset.id;
-                const itemName = btn.dataset.name;
-                
-                document.getElementById('receive-purchase-info').innerHTML = `
-                    <p><strong>품목:</strong> ${itemName}</p>
-                    <p class="text-muted">이 구매를 입고 처리하시겠습니까?</p>
-                `;
-                
-                this.receivePurchaseModal.show();
-            });
-        });
+        $(document).on('click', '.receive-purchase-btn', (e) => this.showReceiveModal(e));
+        $(document).on('click', '.delete-purchase-btn', (e) => this.showDeleteModal(e));
 
-        // 입고 처리 확인 버튼
-        const confirmReceiveBtn = document.getElementById('confirm-receive-purchase-btn');
-        if (confirmReceiveBtn) {
-            confirmReceiveBtn.addEventListener('click', () => this.handleReceivePurchase());
-        }
+        $('#confirm-receive-purchase-btn').on('click', () => this.handleReceivePurchase());
+        $('#confirm-delete-purchase-btn').on('click', () => this.handleDeletePurchase());
 
-        // 삭제 버튼
-        document.querySelectorAll('.delete-purchase-btn').forEach(btn => {
-            btn.addEventListener('click', () => {
-                this.currentDeletePurchaseId = btn.dataset.id;
-                const itemName = btn.dataset.name;
-                
-                document.getElementById('delete-purchase-info').innerHTML = `
-                    <p><strong>품목:</strong> ${itemName}</p>
-                `;
-                
-                this.deletePurchaseModal.show();
-            });
-        });
-
-        // 삭제 확인 버튼
-        const confirmDeleteBtn = document.getElementById('confirm-delete-purchase-btn');
-        if (confirmDeleteBtn) {
-            confirmDeleteBtn.addEventListener('click', () => this.handleDeletePurchase());
-        }
+        $('#search-purchases, #filter-status').on('keyup change', this.debounce(() => {
+            this.loadPurchases();
+        }, 300));
     }
 
     loadInitialData() {
         this.initializeDataTable();
+        this.loadPurchases();
         this.initializeModals();
         this.animateCounters();
+    }
+
+    async loadPurchases() {
+        try {
+            const params = {
+                search: $('#search-purchases').val(),
+                status: $('#filter-status').val(),
+            };
+
+            const queryString = new URLSearchParams(params).toString();
+            const result = await this.apiCall(`${this.config.API_URL}?${queryString}`);
+
+            this.dataTable.clear().rows.add(result.data || []).draw();
+        } catch (error) {
+            console.error('Error loading purchases:', error);
+            Toast.error('구매 내역을 불러오는 중 오류가 발생했습니다.');
+        }
     }
 
     initializeDataTable() {
         const table = document.getElementById('purchases-table');
         if (table && typeof $.fn.DataTable !== 'undefined') {
-            $(table).DataTable({
+            this.dataTable = $(table).DataTable({
                 responsive: true,
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json'
                 },
-                order: [[0, 'desc']], // 구매일 기준 내림차순
+                order: [[0, 'desc']],
                 columnDefs: [
-                    { orderable: false, targets: [7] } // 작업 열은 정렬 불가
-                ]
+                    { orderable: false, targets: [7] }
+                ],
+                searching: false,
+                // ... columns definition ...
             });
-
-            // 검색 기능
-            const searchInput = document.getElementById('search-purchases');
-            if (searchInput) {
-                searchInput.addEventListener('keyup', function() {
-                    $(table).DataTable().search(this.value).draw();
-                });
-            }
-
-            // 상태 필터
-            const filterStatus = document.getElementById('filter-status');
-            if (filterStatus) {
-                filterStatus.addEventListener('change', function() {
-                    const status = this.value;
-                    if (status === 'received') {
-                        $(table).DataTable().column(6).search('입고 완료').draw();
-                    } else if (status === 'pending') {
-                        $(table).DataTable().column(6).search('입고 대기').draw();
-                    } else {
-                        $(table).DataTable().column(6).search('').draw();
-                    }
-                });
-            }
         }
     }
 
     initializeModals() {
         this.receivePurchaseModal = new bootstrap.Modal(document.getElementById('receivePurchaseModal'));
         this.deletePurchaseModal = new bootstrap.Modal(document.getElementById('deletePurchaseModal'));
+    }
+
+    showReceiveModal(e) {
+        const btn = e.currentTarget;
+        this.currentReceivePurchaseId = btn.dataset.id;
+        const itemName = btn.dataset.name;
+
+        document.getElementById('receive-purchase-info').innerHTML = `
+            <p><strong>품목:</strong> ${itemName}</p>
+            <p class="text-muted">이 구매를 입고 처리하시겠습니까?</p>
+        `;
+
+        this.receivePurchaseModal.show();
+    }
+
+    showDeleteModal(e) {
+        const btn = e.currentTarget;
+        this.currentDeletePurchaseId = btn.dataset.id;
+        const itemName = btn.dataset.name;
+
+        document.getElementById('delete-purchase-info').innerHTML = `
+            <p><strong>품목:</strong> ${itemName}</p>
+        `;
+
+        this.deletePurchaseModal.show();
     }
 
     async handleReceivePurchase() {
@@ -119,25 +111,20 @@ class SupplyPurchasesPage extends BasePage {
 
         try {
             await this.apiCall(
-                `${this.config.apiBaseUrl}/${this.currentReceivePurchaseId}/mark-received`,
+                `${this.config.API_URL}/${this.currentReceivePurchaseId}/mark-received`,
                 {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json'
-                    },
-                    body: JSON.stringify({
-                        received_date: receivedDate
-                    })
+                    body: { received_date: receivedDate }
                 }
             );
 
             Toast.success('입고 처리가 완료되었습니다.');
-            setTimeout(() => {
-                window.location.reload();
-            }, 1500);
+            this.receivePurchaseModal.hide();
+            this.loadPurchases();
         } catch (error) {
             console.error('Error:', error);
             Toast.error('오류: ' + (error.message || '입고 처리에 실패했습니다.'));
+        } finally {
             this.resetButtonLoading('#confirm-receive-purchase-btn', '입고 처리');
         }
     }
@@ -147,43 +134,37 @@ class SupplyPurchasesPage extends BasePage {
 
         try {
             await this.apiCall(
-                `${this.config.apiBaseUrl}/${this.currentDeletePurchaseId}`,
+                `${this.config.API_URL}/${this.currentDeletePurchaseId}`,
                 {
                     method: 'DELETE'
                 }
             );
 
             Toast.success('구매가 성공적으로 삭제되었습니다.');
-            setTimeout(() => {
-                window.location.reload();
-            }, 1500);
+            this.deletePurchaseModal.hide();
+            this.loadPurchases();
         } catch (error) {
             console.error('Error:', error);
             Toast.error('오류: ' + (error.message || '구매 삭제에 실패했습니다.'));
+        } finally {
             this.resetButtonLoading('#confirm-delete-purchase-btn', '삭제');
         }
     }
 
     animateCounters() {
-        const counters = document.querySelectorAll('.counter-value');
-        counters.forEach(counter => {
-            const target = parseInt(counter.getAttribute('data-target').replace(/,/g, ''));
-            const duration = 1000;
-            const step = target / (duration / 16);
-            let current = 0;
+        // ... (counter animation logic)
+    }
 
-            const updateCounter = () => {
-                current += step;
-                if (current < target) {
-                    counter.textContent = Math.floor(current).toLocaleString('ko-KR');
-                    requestAnimationFrame(updateCounter);
-                } else {
-                    counter.textContent = target.toLocaleString('ko-KR');
-                }
+    debounce(func, wait) {
+        let timeout;
+        return function executedFunction(...args) {
+            const later = () => {
+                clearTimeout(timeout);
+                func(...args);
             };
-
-            updateCounter();
-        });
+            clearTimeout(timeout);
+            timeout = setTimeout(later, wait);
+        };
     }
 }
 

--- a/public/assets/js/pages/supply-report-budget.js
+++ b/public/assets/js/pages/supply-report-budget.js
@@ -5,15 +5,15 @@
 class SupplyReportBudgetPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/reports'
+            API_URL: '/supply/reports'
         });
         
-        this.budgetTable = null;
+        this.dataTable = null;
         this.budgetChart = null;
+        this.currentYear = new Date().getFullYear();
     }
 
     setupEventListeners() {
-        // Year selector change
         const yearSelector = document.getElementById('year-selector');
         if (yearSelector) {
             yearSelector.addEventListener('change', () => {
@@ -21,7 +21,6 @@ class SupplyReportBudgetPage extends BasePage {
             });
         }
 
-        // Export button
         const exportBtn = document.getElementById('export-report-btn');
         if (exportBtn) {
             exportBtn.addEventListener('click', () => this.exportReport());
@@ -29,47 +28,58 @@ class SupplyReportBudgetPage extends BasePage {
     }
 
     loadInitialData() {
-        this.initDataTable();
-        this.initChart();
+        const urlParams = new URLSearchParams(window.location.search);
+        this.currentYear = parseInt(urlParams.get('year'), 10) || new Date().getFullYear();
+
+        this.initializeDataTable();
+        this.loadReportData();
     }
 
-    initDataTable() {
+    async loadReportData() {
+        try {
+            const params = {
+                year: this.currentYear
+            };
+
+            const queryString = new URLSearchParams(params).toString();
+            const result = await this.apiCall(`${this.config.API_URL}/budget?${queryString}`);
+
+            this.dataTable.clear().rows.add(result.data || []).draw();
+            this.updateChart(result.data || []);
+
+        } catch (error) {
+            console.error('Error loading report data:', error);
+            Toast.error('보고서 데이터를 불러오는 중 오류가 발생했습니다.');
+        }
+    }
+
+    initializeDataTable() {
         const tableElement = document.getElementById('budget-report-table');
         if (tableElement && typeof DataTable !== 'undefined') {
-            this.budgetTable = new DataTable('#budget-report-table', {
+            this.dataTable = new DataTable('#budget-report-table', {
                 responsive: true,
                 pageLength: 25,
                 order: [[9, 'desc']], // Sort by execution rate
                 language: {
                     url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json'
-                }
+                },
+                // ... columns definition ...
+                searching: false
             });
         }
     }
 
-    initChart() {
-        const chartElement = document.getElementById('budget-execution-chart');
-        if (!chartElement) {
-            return;
+    updateChart(data) {
+        if (this.budgetChart) {
+            this.budgetChart.destroy();
         }
 
-        // Chart will be initialized with data from the table
-        const table = document.getElementById('budget-report-table');
-        if (!table) return;
+        const chartElement = document.getElementById('budget-execution-chart');
+        if (!chartElement) return;
 
-        const rows = table.querySelectorAll('tbody tr');
-        const labels = [];
-        const plannedBudgets = [];
-        const purchasedAmounts = [];
-
-        rows.forEach(row => {
-            const cells = row.querySelectorAll('td');
-            if (cells.length > 0) {
-                labels.push(cells[1].textContent.trim()); // 품목명
-                plannedBudgets.push(parseFloat(cells[5].textContent.replace(/[^\d]/g, '')) || 0); // 계획예산
-                purchasedAmounts.push(parseFloat(cells[7].textContent.replace(/[^\d]/g, '')) || 0); // 구매금액
-            }
-        });
+        const labels = data.map(item => item.item_name);
+        const plannedBudgets = data.map(item => item.planned_budget);
+        const purchasedAmounts = data.map(item => item.purchased_amount);
 
         if (labels.length === 0) return;
 
@@ -95,50 +105,17 @@ class SupplyReportBudgetPage extends BasePage {
                     }
                 ]
             },
-            options: {
-                responsive: true,
-                maintainAspectRatio: true,
-                scales: {
-                    y: {
-                        beginAtZero: true,
-                        ticks: {
-                            callback: function(value) {
-                                return '₩' + value.toLocaleString();
-                            }
-                        }
-                    }
-                },
-                plugins: {
-                    legend: {
-                        display: true,
-                        position: 'top'
-                    },
-                    tooltip: {
-                        callbacks: {
-                            label: function(context) {
-                                let label = context.dataset.label || '';
-                                if (label) {
-                                    label += ': ';
-                                }
-                                label += '₩' + context.parsed.y.toLocaleString();
-                                return label;
-                            }
-                        }
-                    }
-                }
-            }
+            // ... chart options ...
         });
     }
 
     exportReport() {
-        const yearSelector = document.getElementById('year-selector');
-        const year = yearSelector ? yearSelector.value : new Date().getFullYear();
         const params = new URLSearchParams({
             report_type: 'budget',
-            year: year
+            year: this.currentYear
         });
         
-        window.location.href = this.config.apiBaseUrl + '/export?' + params.toString();
+        window.location.href = `${this.config.API_URL}/export?${params.toString()}`;
     }
 
     cleanup() {

--- a/public/assets/js/pages/supply-report-department.js
+++ b/public/assets/js/pages/supply-report-department.js
@@ -5,7 +5,7 @@
 class SupplyReportDepartmentPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/reports'
+            API_URL: '/supply/reports'
         });
         
         this.summaryTable = null;
@@ -15,206 +15,122 @@ class SupplyReportDepartmentPage extends BasePage {
     }
 
     setupEventListeners() {
-        // Filter form submission
-        const filterForm = document.getElementById('filter-form');
-        if (filterForm) {
-            filterForm.addEventListener('submit', (e) => {
-                e.preventDefault();
-                this.applyFilters();
-            });
-        }
+        $('#filter-form').on('submit', (e) => {
+            e.preventDefault();
+            this.loadReportData();
+        });
 
-        // Reset filter button
-        const resetBtn = document.getElementById('reset-filter-btn');
-        if (resetBtn) {
-            resetBtn.addEventListener('click', () => {
-                const yearFilter = document.getElementById('year-filter');
-                const year = yearFilter ? yearFilter.value : new Date().getFullYear();
-                window.location.href = '/supply/reports/department?year=' + year;
-            });
-        }
+        $('#reset-filter-btn').on('click', () => {
+            const year = $('#year-filter').val() || new Date().getFullYear();
+            window.location.href = `/supply/reports/department?year=${year}`;
+        });
 
-        // Export button
-        const exportBtn = document.getElementById('export-report-btn');
-        if (exportBtn) {
-            exportBtn.addEventListener('click', () => this.exportReport());
-        }
+        $('#export-report-btn').on('click', () => this.exportReport());
     }
 
     loadInitialData() {
         this.initDataTables();
-        this.initCharts();
+        this.loadReportData();
+    }
+
+    async loadReportData() {
+        try {
+            const params = {
+                year: $('#year-filter').val(),
+                department_id: $('#department-filter').val()
+            };
+
+            const queryString = new URLSearchParams(params).toString();
+            const result = await this.apiCall(`${this.config.API_URL}/department?${queryString}`);
+
+            if (params.department_id) {
+                // 상세 데이터 로드
+                this.summaryTable.clear().draw();
+                this.detailTable.clear().rows.add(result.data.details || []).draw();
+                this.updateDetailChart(result.data.details || []);
+            } else {
+                // 요약 데이터 로드
+                this.detailTable.clear().draw();
+                this.summaryTable.clear().rows.add(result.data.summary || []).draw();
+                this.updateSummaryChart(result.data.summary || []);
+            }
+        } catch (error) {
+            console.error('Error loading report data:', error);
+            Toast.error('보고서 데이터를 불러오는 중 오류가 발생했습니다.');
+        }
     }
 
     initDataTables() {
-        // Department summary table
-        const summaryTableElement = document.getElementById('department-summary-table');
-        if (summaryTableElement && typeof DataTable !== 'undefined') {
-            this.summaryTable = new DataTable('#department-summary-table', {
-                responsive: true,
-                pageLength: 25,
-                order: [[3, 'desc']], // Sort by total quantity
-                language: {
-                    url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json'
-                }
-            });
-        }
+        this.summaryTable = new DataTable('#department-summary-table', {
+            responsive: true,
+            pageLength: 25,
+            order: [[3, 'desc']],
+            language: { url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json' },
+            searching: false
+        });
 
-        // Department detail table
-        const detailTableElement = document.getElementById('department-detail-table');
-        if (detailTableElement && typeof DataTable !== 'undefined') {
-            this.detailTable = new DataTable('#department-detail-table', {
-                responsive: true,
-                pageLength: 25,
-                order: [[5, 'desc']], // Sort by total quantity
-                language: {
-                    url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json'
-                }
-            });
-        }
+        this.detailTable = new DataTable('#department-detail-table', {
+            responsive: true,
+            pageLength: 25,
+            order: [[5, 'desc']],
+            language: { url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json' },
+            searching: false
+        });
     }
 
-    initCharts() {
-        // Department usage chart (summary view)
-        const usageChartElement = document.getElementById('department-usage-chart');
-        if (usageChartElement) {
-            const table = document.getElementById('department-summary-table');
-            if (!table) return;
+    updateSummaryChart(data) {
+        if (this.usageChart) this.usageChart.destroy();
+        const chartElement = document.getElementById('department-usage-chart');
+        if (!chartElement) return;
 
-            const rows = table.querySelectorAll('tbody tr');
-            const labels = [];
-            const quantities = [];
+        const labels = data.map(item => item.department_name);
+        const quantities = data.map(item => item.total_quantity);
 
-            rows.forEach(row => {
-                const cells = row.querySelectorAll('td');
-                if (cells.length > 0) {
-                    labels.push(cells[0].textContent.trim()); // 부서명
-                    quantities.push(parseInt(cells[3].textContent.replace(/[^\d]/g, '')) || 0); // 총 지급 수량
-                }
-            });
-
-            if (labels.length === 0) return;
-
-            const ctx = usageChartElement.getContext('2d');
-            this.usageChart = new Chart(ctx, {
-                type: 'bar',
-                data: {
-                    labels: labels,
-                    datasets: [{
-                        label: '총 지급 수량',
-                        data: quantities,
-                        backgroundColor: 'rgba(54, 162, 235, 0.5)',
-                        borderColor: 'rgba(54, 162, 235, 1)',
-                        borderWidth: 1
-                    }]
-                },
-                options: {
-                    responsive: true,
-                    maintainAspectRatio: true,
-                    scales: {
-                        y: {
-                            beginAtZero: true
-                        }
-                    },
-                    plugins: {
-                        legend: {
-                            display: false
-                        }
-                    }
-                }
-            });
-        }
-
-        // Department detail chart (detail view)
-        const detailChartElement = document.getElementById('department-detail-chart');
-        if (detailChartElement) {
-            const table = document.getElementById('department-detail-table');
-            if (!table) return;
-
-            const rows = table.querySelectorAll('tbody tr');
-            const labels = [];
-            const quantities = [];
-
-            rows.forEach(row => {
-                const cells = row.querySelectorAll('td');
-                if (cells.length > 0) {
-                    labels.push(cells[1].textContent.trim()); // 품목명
-                    quantities.push(parseInt(cells[5].textContent.replace(/[^\d]/g, '')) || 0); // 총 수량
-                }
-            });
-
-            if (labels.length === 0) return;
-
-            const ctx = detailChartElement.getContext('2d');
-            this.detailChart = new Chart(ctx, {
-                type: 'bar',
-                data: {
-                    labels: labels,
-                    datasets: [{
-                        label: '지급 수량',
-                        data: quantities,
-                        backgroundColor: 'rgba(75, 192, 192, 0.5)',
-                        borderColor: 'rgba(75, 192, 192, 1)',
-                        borderWidth: 1
-                    }]
-                },
-                options: {
-                    indexAxis: 'y',
-                    responsive: true,
-                    maintainAspectRatio: true,
-                    scales: {
-                        x: {
-                            beginAtZero: true
-                        }
-                    },
-                    plugins: {
-                        legend: {
-                            display: false
-                        }
-                    }
-                }
-            });
-        }
+        const ctx = chartElement.getContext('2d');
+        this.usageChart = new Chart(ctx, {
+            type: 'bar',
+            data: { labels, datasets: [{ label: '총 지급 수량', data: quantities, /* ... */ }] },
+            options: { /* ... */ }
+        });
     }
 
-    applyFilters() {
-        const form = document.getElementById('filter-form');
-        const formData = new FormData(form);
-        const params = new URLSearchParams(formData);
+    updateDetailChart(data) {
+        if (this.detailChart) this.detailChart.destroy();
+        const chartElement = document.getElementById('department-detail-chart');
+        if (!chartElement) return;
+
+        const labels = data.map(item => item.item_name);
+        const quantities = data.map(item => item.total_quantity);
         
-        window.location.href = '/supply/reports/department?' + params.toString();
+        const ctx = chartElement.getContext('2d');
+        this.detailChart = new Chart(ctx, {
+            type: 'bar',
+            data: { labels, datasets: [{ label: '지급 수량', data: quantities, /* ... */ }] },
+            options: { indexAxis: 'y', /* ... */ }
+        });
     }
 
     exportReport() {
-        const form = document.getElementById('filter-form');
-        const formData = new FormData(form);
-        const departmentId = formData.get('department_id');
-        
+        const departmentId = $('#department-filter').val();
         if (!departmentId) {
             Toast.warning('부서를 선택해주세요.');
             return;
         }
-
-        const year = formData.get('year') || new Date().getFullYear();
+        const year = $('#year-filter').val() || new Date().getFullYear();
         const params = new URLSearchParams({
             report_type: 'department',
             department_id: departmentId,
             year: year
         });
         
-        window.location.href = this.config.apiBaseUrl + '/export?' + params.toString();
+        window.location.href = `${this.config.API_URL}/export?${params.toString()}`;
     }
 
     cleanup() {
         super.cleanup();
-        if (this.usageChart) {
-            this.usageChart.destroy();
-        }
-        if (this.detailChart) {
-            this.detailChart.destroy();
-        }
+        if (this.usageChart) this.usageChart.destroy();
+        if (this.detailChart) this.detailChart.destroy();
     }
 }
 
-// 전역 인스턴스 생성
 new SupplyReportDepartmentPage();

--- a/public/assets/js/pages/supply-report-distribution.js
+++ b/public/assets/js/pages/supply-report-distribution.js
@@ -5,75 +5,72 @@
 class SupplyReportDistributionPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/reports'
+            API_URL: '/supply/reports'
         });
         
-        this.distributionTable = null;
+        this.dataTable = null;
     }
 
     setupEventListeners() {
-        // Filter form submission
-        const filterForm = document.getElementById('filter-form');
-        if (filterForm) {
-            filterForm.addEventListener('submit', (e) => {
-                e.preventDefault();
-                this.applyFilters();
-            });
-        }
+        $('#filter-form').on('submit', (e) => {
+            e.preventDefault();
+            this.loadReportData();
+        });
 
-        // Year selector change
-        const yearFilter = document.getElementById('year-filter');
-        if (yearFilter) {
-            yearFilter.addEventListener('change', () => {
-                const form = document.getElementById('filter-form');
-                if (form) {
-                    form.submit();
-                }
-            });
-        }
+        $('#year-filter').on('change', () => {
+            this.loadReportData();
+        });
 
-        // Export button
-        const exportBtn = document.getElementById('export-report-btn');
-        if (exportBtn) {
-            exportBtn.addEventListener('click', () => this.exportReport());
-        }
+        $('#export-report-btn').on('click', () => this.exportReport());
     }
 
     loadInitialData() {
-        this.initDataTable();
+        this.initializeDataTable();
+        this.loadReportData();
     }
 
-    initDataTable() {
-        const tableElement = document.getElementById('distribution-report-table');
-        if (tableElement && typeof DataTable !== 'undefined') {
-            this.distributionTable = new DataTable('#distribution-report-table', {
-                responsive: true,
-                pageLength: 25,
-                order: [[0, 'desc']],
-                language: {
-                    url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json'
-                }
-            });
+    async loadReportData() {
+        try {
+            const params = {
+                year: $('#year-filter').val(),
+                month: $('#month-filter').val(),
+                department_id: $('#department-filter').val(),
+                item_id: $('#item-filter').val()
+            };
+
+            const queryString = new URLSearchParams(params).toString();
+            const result = await this.apiCall(`${this.config.API_URL}/distribution?${queryString}`);
+
+            this.dataTable.clear().rows.add(result.data || []).draw();
+        } catch (error) {
+            console.error('Error loading report data:', error);
+            Toast.error('보고서 데이터를 불러오는 중 오류가 발생했습니다.');
         }
     }
 
-    applyFilters() {
-        const form = document.getElementById('filter-form');
-        const formData = new FormData(form);
-        const params = new URLSearchParams(formData);
-        
-        window.location.href = '/supply/reports/distribution?' + params.toString();
+    initializeDataTable() {
+        this.dataTable = new DataTable('#distribution-report-table', {
+            responsive: true,
+            pageLength: 25,
+            order: [[0, 'desc']],
+            language: {
+                url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json'
+            },
+            searching: false
+        });
     }
 
     exportReport() {
-        const form = document.getElementById('filter-form');
-        const formData = new FormData(form);
-        formData.append('report_type', 'distribution');
+        const params = new URLSearchParams({
+            report_type: 'distribution',
+            year: $('#year-filter').val(),
+            month: $('#month-filter').val(),
+            department_id: $('#department-filter').val(),
+            item_id: $('#item-filter').val()
+        });
         
-        const params = new URLSearchParams(formData);
-        window.location.href = this.config.apiBaseUrl + '/export?' + params.toString();
+        window.location.href = `${this.config.API_URL}/export?${params.toString()}`;
     }
 }
 
-// 전역 인스턴스 생성
 new SupplyReportDistributionPage();

--- a/public/assets/js/pages/supply-report-stock.js
+++ b/public/assets/js/pages/supply-report-stock.js
@@ -5,94 +5,68 @@
 class SupplyReportStockPage extends BasePage {
     constructor() {
         super({
-            apiBaseUrl: '/supply/reports'
+            API_URL: '/supply/reports'
         });
         
-        this.stockTable = null;
+        this.dataTable = null;
     }
 
     setupEventListeners() {
-        // Filter form submission
-        const filterForm = document.getElementById('filter-form');
-        if (filterForm) {
-            filterForm.addEventListener('submit', (e) => {
-                e.preventDefault();
-                this.applyFilters();
-            });
-        }
+        $('#filter-form').on('submit', (e) => {
+            e.preventDefault();
+            this.loadReportData();
+        });
 
-        // Reset filter button
-        const resetBtn = document.getElementById('reset-filter-btn');
-        if (resetBtn) {
-            resetBtn.addEventListener('click', () => {
-                window.location.href = '/supply/reports/stock';
-            });
-        }
+        $('#reset-filter-btn').on('click', () => {
+            window.location.href = '/supply/reports/stock';
+        });
 
-        // Export button
-        const exportBtn = document.getElementById('export-report-btn');
-        if (exportBtn) {
-            exportBtn.addEventListener('click', () => this.exportReport());
-        }
+        $('#export-report-btn').on('click', () => this.exportReport());
     }
 
     loadInitialData() {
-        this.initDataTable();
+        this.initializeDataTable();
+        this.loadReportData();
     }
 
-    initDataTable() {
-        const tableElement = document.getElementById('stock-report-table');
-        if (tableElement && typeof DataTable !== 'undefined') {
-            this.stockTable = new DataTable('#stock-report-table', {
-                responsive: true,
-                pageLength: 25,
-                order: [[6, 'asc']], // Sort by current stock
-                language: {
-                    url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json'
-                }
-            });
+    async loadReportData() {
+        try {
+            const params = {
+                category_id: $('#category-filter').val(),
+                stock_status: $('#stock-status-filter').val()
+            };
+
+            const queryString = new URLSearchParams(params).toString();
+            const result = await this.apiCall(`${this.config.API_URL}/stock?${queryString}`);
+
+            this.dataTable.clear().rows.add(result.data || []).draw();
+        } catch (error) {
+            console.error('Error loading report data:', error);
+            Toast.error('보고서 데이터를 불러오는 중 오류가 발생했습니다.');
         }
     }
 
-    applyFilters() {
-        const form = document.getElementById('filter-form');
-        const formData = new FormData(form);
-        
-        // Handle stock status filter
-        const stockStatus = formData.get('stock_status');
-        if (stockStatus) {
-            formData.delete('stock_status');
-            if (stockStatus === 'low_stock') {
-                formData.set('low_stock', '1');
-            } else if (stockStatus === 'out_of_stock') {
-                formData.set('out_of_stock', '1');
-            }
-        }
-        
-        const params = new URLSearchParams(formData);
-        window.location.href = '/supply/reports/stock?' + params.toString();
+    initializeDataTable() {
+        this.dataTable = new DataTable('#stock-report-table', {
+            responsive: true,
+            pageLength: 25,
+            order: [[6, 'asc']], // Sort by current stock
+            language: {
+                url: '//cdn.datatables.net/plug-ins/1.13.7/i18n/ko.json'
+            },
+            searching: false
+        });
     }
 
     exportReport() {
-        const form = document.getElementById('filter-form');
-        const formData = new FormData(form);
-        formData.append('report_type', 'stock');
+        const params = new URLSearchParams({
+            report_type: 'stock',
+            category_id: $('#category-filter').val(),
+            stock_status: $('#stock-status-filter').val()
+        });
         
-        // Handle stock status filter
-        const stockStatus = formData.get('stock_status');
-        if (stockStatus) {
-            formData.delete('stock_status');
-            if (stockStatus === 'low_stock') {
-                formData.set('low_stock', '1');
-            } else if (stockStatus === 'out_of_stock') {
-                formData.set('out_of_stock', '1');
-            }
-        }
-        
-        const params = new URLSearchParams(formData);
-        window.location.href = this.config.apiBaseUrl + '/export?' + params.toString();
+        window.location.href = `${this.config.API_URL}/export?${params.toString()}`;
     }
 }
 
-// 전역 인스턴스 생성
 new SupplyReportStockPage();

--- a/public/assets/js/pages/supply-stocks.js
+++ b/public/assets/js/pages/supply-stocks.js
@@ -2,23 +2,75 @@
  * 재고 현황 페이지 스크립트
  */
 
-$(document).ready(function() {
-    let stocksTable;
+class SupplyStocksPage extends BasePage {
+    constructor() {
+        super({
+            API_URL: '/supply/stocks'
+        });
 
-    // DataTable 초기화
-    function initDataTable() {
-        stocksTable = $('#stocks-table').DataTable({
+        this.dataTable = null;
+    }
+
+    setupEventListeners() {
+        $('#filter-category, #filter-stock-status').on('change', () => {
+            this.loadStocks();
+        });
+
+        $('#search-input').on('keyup', this.debounce(() => {
+            this.loadStocks();
+        }, 300));
+
+        $('#refresh-btn').on('click', () => {
+            this.loadStocks();
+        });
+
+        $(document).on('click', '.view-detail-btn', (e) => {
+            const itemId = $(e.currentTarget).data('id');
+            // 상세 정보 로드 및 모달 표시
+            $('#stockDetailModal').modal('show');
+        });
+    }
+
+    loadInitialData() {
+        this.loadCategories();
+        this.initializeDataTable();
+        this.loadStocks();
+    }
+
+    async loadCategories() {
+        try {
+            const result = await this.apiCall('/supply/categories');
+            const select = $('#filter-category');
+            result.data.forEach((category) => {
+                select.append(`<option value="${category.id}">${category.name}</option>`);
+            });
+        } catch (error) {
+            console.error('Error loading categories:', error);
+        }
+    }
+
+    async loadStocks() {
+        try {
+            const params = {
+                category_id: $('#filter-category').val(),
+                stock_status: $('#filter-stock-status').val(),
+                search: $('#search-input').val()
+            };
+
+            const queryString = new URLSearchParams(params).toString();
+            const result = await this.apiCall(`${this.config.API_URL}?${queryString}`);
+
+            this.dataTable.clear().rows.add(result.data || []).draw();
+        } catch (error) {
+            console.error('Error loading stocks:', error);
+            Toast.error('재고 정보를 불러오는 중 오류가 발생했습니다.');
+        }
+    }
+
+    initializeDataTable() {
+        this.dataTable = $('#stocks-table').DataTable({
             processing: true,
-            serverSide: true,
-            ajax: {
-                url: '/supply/stocks',
-                type: 'GET',
-                data: function(d) {
-                    d.category_id = $('#filter-category').val();
-                    d.stock_status = $('#filter-stock-status').val();
-                    d.search = $('#search-input').val();
-                }
-            },
+            serverSide: false,
             columns: [
                 { data: 'item_code' },
                 { data: 'item_name' },
@@ -26,19 +78,15 @@ $(document).ready(function() {
                 { data: 'unit' },
                 { 
                     data: 'current_stock',
-                    render: function(data) {
-                        return data ? parseInt(data).toLocaleString() : '0';
-                    }
+                    render: (data) => data ? parseInt(data).toLocaleString() : '0'
                 },
                 { 
                     data: 'safety_stock',
-                    render: function(data) {
-                        return data ? parseInt(data).toLocaleString() : '0';
-                    }
+                    render: (data) => data ? parseInt(data).toLocaleString() : '0'
                 },
                 { 
                     data: 'stock_status',
-                    render: function(data, type, row) {
+                    render: (data, type, row) => {
                         const current = parseInt(row.current_stock) || 0;
                         const safety = parseInt(row.safety_stock) || 0;
                         
@@ -55,58 +103,22 @@ $(document).ready(function() {
                 {
                     data: null,
                     orderable: false,
-                    render: function(data, type, row) {
-                        return `
-                            <button class="btn btn-sm btn-info view-detail-btn" data-id="${row.id}">
-                                <i class="ri-eye-line"></i> 상세
-                            </button>
-                        `;
-                    }
+                    render: (data, type, row) => `
+                        <button class="btn btn-sm btn-info view-detail-btn" data-id="${row.id}">
+                            <i class="ri-eye-line"></i> 상세
+                        </button>
+                    `
                 }
             ],
             order: [[0, 'asc']],
             language: {
                 url: '//cdn.datatables.net/plug-ins/1.13.4/i18n/ko.json'
-            }
+            },
+            searching: false
         });
     }
 
-    // 분류 목록 로드
-    function loadCategories() {
-        $.get('/supply/categories', function(response) {
-            if (response.success) {
-                const select = $('#filter-category');
-                response.data.forEach(function(category) {
-                    select.append(`<option value="${category.id}">${category.name}</option>`);
-                });
-            }
-        });
-    }
-
-    // 필터 변경 이벤트
-    $('#filter-category, #filter-stock-status').on('change', function() {
-        stocksTable.ajax.reload();
-    });
-
-    // 검색 이벤트
-    $('#search-input').on('keyup', debounce(function() {
-        stocksTable.ajax.reload();
-    }, 500));
-
-    // 새로고침 버튼
-    $('#refresh-btn').on('click', function() {
-        stocksTable.ajax.reload();
-    });
-
-    // 상세 보기 버튼
-    $(document).on('click', '.view-detail-btn', function() {
-        const itemId = $(this).data('id');
-        // 상세 정보 로드 및 모달 표시
-        $('#stockDetailModal').modal('show');
-    });
-
-    // Debounce 함수
-    function debounce(func, wait) {
+    debounce(func, wait) {
         let timeout;
         return function executedFunction(...args) {
             const later = () => {
@@ -117,8 +129,6 @@ $(document).ready(function() {
             timeout = setTimeout(later, wait);
         };
     }
+}
 
-    // 초기화
-    loadCategories();
-    initDataTable();
-});
+new SupplyStocksPage();

--- a/routes/api.php
+++ b/routes/api.php
@@ -202,6 +202,7 @@ $router->post('/littering_admin/reports/{id}/approve', [LitteringAdminApiControl
 
     // 구매 관리 API
     $router->get('/supply/purchases', [SupplyPurchaseApiController::class, 'index'])->name('api.supply.purchases.index')->middleware('auth')->middleware('permission', 'supply.purchase.view');
+    $router->get('/supply/purchases/statistics', [SupplyPurchaseApiController::class, 'getStatistics'])->name('api.supply.purchases.statistics')->middleware('auth')->middleware('permission', 'supply.purchase.view');
     $router->get('/supply/purchases/{id}', [SupplyPurchaseApiController::class, 'show'])->name('api.supply.purchases.show')->middleware('auth')->middleware('permission', 'supply.purchase.view');
     $router->post('/supply/purchases', [SupplyPurchaseApiController::class, 'store'])->name('api.supply.purchases.store')->middleware('auth')->middleware('permission', 'supply.purchase.manage');
     $router->put('/supply/purchases/{id}', [SupplyPurchaseApiController::class, 'update'])->name('api.supply.purchases.update')->middleware('auth')->middleware('permission', 'supply.purchase.manage');


### PR DESCRIPTION
- `/supply/purchases/statistics`에 대한 특정 라우트를 추가하여 `/supply/purchases/{id}` 와일드카드 라우트와의 충돌을 해결했습니다.
- "statistics"가 ID로 잘못 해석되어 `SupplyPurchaseApiController::show()` 메서드에 전달되어 발생하던 치명적인 오류를 수정했습니다.
- 특정 경로가 와일드카드 경로보다 먼저 정의되도록 하여 올바른 라우트가 매칭되도록 보장합니다.