### PR TITLE
Fix: supply 모듈의 구매 등록 오류 및 ActivityLogger 문제 해결

### DIFF
--- a/app/Services/SupplyDistributionService.php
+++ b/app/Services/SupplyDistributionService.php
@@ -79,7 +79,11 @@ class SupplyDistributionService
                 'distribution_date' => $distributionDate,
                 'distributed_by' => $distributedBy
             ];
-            $this->activityLogger->logSupplyDistributionCreate($distributionId, $distributionData);
+            $this->activityLogger->log(
+                'supply_distribution_create',
+                "신규 지급 등록 (ID: {$distributionId})",
+                $distributionData
+            );
 
             $this->db->commit();
 
@@ -187,7 +191,11 @@ class SupplyDistributionService
             $this->stockService->updateStockFromCancelDistribution($itemId, $quantity);
 
             // 감사 로그 기록
-            $this->activityLogger->logSupplyDistributionCancel($distributionId, $distribution->toArray(), $reason);
+            $this->activityLogger->log(
+                'supply_distribution_cancel',
+                "지급 취소 (ID: {$distributionId})",
+                ['distribution' => $distribution->toArray(), 'reason' => $reason]
+            );
 
             $this->db->commit();
 
@@ -254,8 +262,12 @@ class SupplyDistributionService
 
             // 감사 로그 기록
             $oldData = $distribution->toArray();
-            $newData = array_merge($oldData, $updateData);
-            $this->activityLogger->logSupplyDistributionUpdate($distributionId, $oldData, $newData);
+            $newData = array_merge($oldData, $data);
+            $this->activityLogger->log(
+                'supply_distribution_update',
+                "지급 정보 수정 (ID: {$distributionId})",
+                ['old' => $oldData, 'new' => $newData]
+            );
 
             $this->db->commit();
 

--- a/app/Services/SupplyPurchaseService.php
+++ b/app/Services/SupplyPurchaseService.php
@@ -61,15 +61,18 @@ class SupplyPurchaseService
 
         // 입고 완료 상태면 재고 업데이트
         if (isset($purchaseData['is_received']) && $purchaseData['is_received']) {
-            $this->stockRepository->updateStock(
+            $this->stockService->updateStockFromPurchase(
                 $purchaseData['item_id'],
-                $purchaseData['quantity'],
-                'purchase'
+                $purchaseData['quantity']
             );
         }
 
         // 활동 로그 기록
-        $this->activityLogger->logSupplyPurchaseCreate($purchaseId, $purchaseData);
+        $this->activityLogger->log(
+            'supply_purchase_create',
+            "신규 구매 등록 (ID: {$purchaseId})",
+            $purchaseData
+        );
 
         return $purchaseId > 0;
     }
@@ -110,7 +113,11 @@ class SupplyPurchaseService
             $newData = array_merge($oldData, $updateData);
             
             // 활동 로그 기록
-            $this->activityLogger->logSupplyPurchaseUpdate($purchaseId, $oldData, $newData);
+            $this->activityLogger->log(
+                'supply_purchase_update',
+                "구매 정보 수정 (ID: {$purchaseId})",
+                ['old' => $oldData, 'new' => $newData]
+            );
         }
 
         return $success;
@@ -136,7 +143,11 @@ class SupplyPurchaseService
 
         if ($success) {
             // 활동 로그 기록
-            $this->activityLogger->logSupplyPurchaseDelete($purchaseId, $purchase->toArray());
+            $this->activityLogger->log(
+                'supply_purchase_delete',
+                "구매 삭제 (ID: {$purchaseId})",
+                $purchase->toArray()
+            );
         }
 
         return $success;
@@ -177,17 +188,20 @@ class SupplyPurchaseService
 
             if ($success) {
                 // 재고 업데이트
-                $this->stockRepository->updateStock(
+                $this->stockService->updateStockFromPurchase(
                     $purchase->getAttribute('item_id'),
-                    $purchase->getAttribute('quantity'),
-                    'purchase'
+                    $purchase->getAttribute('quantity')
                 );
 
                 // 활동 로그 기록
-                $this->activityLogger->logSupplyPurchaseReceive($purchaseId, [
-                    'quantity' => $purchase->getAttribute('quantity'),
-                    'received_date' => $receivedDate
-                ]);
+                $this->activityLogger->log(
+                    'supply_purchase_receive',
+                    "구매 입고 처리 (ID: {$purchaseId})",
+                    [
+                        'quantity' => $purchase->getAttribute('quantity'),
+                        'received_date' => $receivedDate
+                    ]
+                );
             }
 
             return $success;

--- a/app/Services/SupplyReportService.php
+++ b/app/Services/SupplyReportService.php
@@ -106,7 +106,11 @@ class SupplyReportService
         $result = $this->db->query($sql, $params);
         
         // 활동 로그 기록
-        $this->activityLogger->logSupplyReportView('distribution', $filters);
+        $this->activityLogger->log(
+            'supply_report_view',
+            "지급 현황 보고서 조회",
+            ['report_type' => 'distribution', 'filters' => $filters]
+        );
         
         return $result;
     }
@@ -310,7 +314,11 @@ class SupplyReportService
         fclose($handle);
 
         // 활동 로그 기록
-        $this->activityLogger->logSupplyReportExport($reportType, $filters ?? []);
+        $this->activityLogger->log(
+            'supply_report_export',
+            "{$reportType} 보고서 내보내기",
+            ['report_type' => $reportType, 'row_count' => count($data)]
+        );
 
         return $filepath;
     }

--- a/tests/SupplyPurchaseApiTest.php
+++ b/tests/SupplyPurchaseApiTest.php
@@ -1,0 +1,91 @@
+<?php
+
+use App\Core\Database;
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class SupplyPurchaseApiTest extends TestCase
+{
+    private Client $http;
+    private static int $createdItemId;
+    private static int $createdPurchaseId;
+
+    public static function setUpBeforeClass(): void
+    {
+        $db = new Database();
+        $pdo = $db->getConnection();
+        $pdo->exec('DELETE FROM supply_purchases');
+        $pdo->exec('DELETE FROM supply_stocks');
+        $pdo->exec('DELETE FROM supply_items');
+        $pdo->exec('DELETE FROM supply_categories');
+
+        // Create a category to associate with the item
+        $stmt = $pdo->prepare("INSERT INTO supply_categories (name) VALUES (?)");
+        $stmt->execute(['Test Category']);
+        $categoryId = $pdo->lastInsertId();
+
+        // Create an item to associate with the purchase
+        $stmt = $pdo->prepare("INSERT INTO supply_items (category_id, name, unit, is_active) VALUES (?, ?, ?, ?)");
+        $stmt->execute([$categoryId, 'Test Item', 'EA', 1]);
+        self::$createdItemId = $pdo->lastInsertId();
+    }
+
+    protected function setUp(): void
+    {
+        $this->http = new Client(['base_uri' => 'http://localhost/api/', 'http_errors' => false]);
+    }
+
+    public function testCreatePurchaseAndVerifyStockUpdate()
+    {
+        $initialStock = $this->getCurrentStock(self::$createdItemId);
+        $this->assertEquals(0, $initialStock);
+
+        $purchaseQuantity = 100;
+
+        $response = $this->http->post('supply-purchases', [
+            'json' => [
+                'item_id' => self::$createdItemId,
+                'purchase_date' => '2025-11-18',
+                'quantity' => $purchaseQuantity,
+                'unit_price' => 500,
+                'is_received' => true,
+                'received_date' => '2025-11-18'
+            ]
+        ]);
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $data = json_decode($response->getBody(), true);
+        $this->assertArrayHasKey('id', $data['data']);
+        self::$createdPurchaseId = $data['data']['id'];
+
+        // Verify stock is updated
+        $updatedStock = $this->getCurrentStock(self::$createdItemId);
+        $this->assertEquals($initialStock + $purchaseQuantity, $updatedStock);
+    }
+
+    public function testGetPurchases()
+    {
+        $response = $this->http->get('supply-purchases');
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getBody(), true);
+        $this->assertIsArray($data['data']);
+    }
+
+    public function testGetPurchaseById()
+    {
+        $response = $this->http->get('supply-purchases/' . self::$createdPurchaseId);
+        $this->assertEquals(200, $response->getStatusCode());
+        $data = json_decode($response->getBody(), true);
+        $this->assertEquals(self::$createdPurchaseId, $data['data']['id']);
+    }
+
+    private function getCurrentStock(int $itemId): int
+    {
+        $db = new Database();
+        $pdo = $db->getConnection();
+        $stmt = $pdo->prepare('SELECT quantity FROM supply_stocks WHERE item_id = ?');
+        $stmt->execute([$itemId]);
+        $result = $stmt->fetchColumn();
+        return $result === false ? 0 : (int) $result;
+    }
+}


### PR DESCRIPTION
`SupplyPurchaseService`에서 초기화되지 않은 `stockRepository`를 호출하여 구매 등록 시 발생하던 Fatal Error를 수정했습니다. `stockService`를 사용하도록 변경하여 문제를 해결했습니다.

또한 `SupplyPurchaseService`, `SupplyDistributionService`, `SupplyReportService`에서 존재하지 않는 메서드를 호출하던 `ActivityLogger`의 사용법을 범용 `log()` 메서드를 사용하도록 전면 수정했습니다.

구매 등록 기능의 정상 동작을 검증하고 향후 회귀를 방지하기 위해 `SupplyPurchaseApiTest.php` 테스트 파일을 추가했습니다.