### PR TITLE
fix(supply): display error on plan deletion failure

### DIFF
--- a/app/Views/pages/supply/plans/index.php
+++ b/app/Views/pages/supply/plans/index.php
@@ -110,7 +110,7 @@
                 <div id="delete-plan-info"></div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn-secondary" data-bs-dismiss="modal">취소</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
                 <button type="button" class="btn btn-danger" id="confirm-delete-plan-btn">삭제</button>
             </div>
         </div>

--- a/public/assets/js/pages/supply-plans-index.js
+++ b/public/assets/js/pages/supply-plans-index.js
@@ -199,6 +199,7 @@ class SupplyPlansIndexPage extends BasePage {
             this.loadPlans();
             this.loadBudgetSummary();
         } catch (error) {
+            this.deletePlanModal.hide();
             this.handleApiError(error);
         } finally {
             this.resetButtonLoading('#confirm-delete-plan-btn', '삭제');
@@ -207,6 +208,7 @@ class SupplyPlansIndexPage extends BasePage {
     }
 
     exportToExcel() {
+        Toast.info('엑셀 다운로드를 시작합니다.');
         window.open(`/api/supply/plans/export-excel/${this.currentYear}`, '_blank');
     }
 
@@ -342,6 +344,12 @@ class SupplyPlansIndexPage extends BasePage {
                 "'": '&#39;'
             }[match];
         });
+    }
+
+    handleApiError(error) {
+        const message = error.message || 'An unexpected error occurred.';
+        Toast.error(message);
+        console.error('API Error:', error);
     }
 }
 


### PR DESCRIPTION
This commit fixes a bug where the error message was not displayed when a user tried to delete a supply plan with existing dependencies.

- Adds a local `handleApiError` method to `supply-plans-index.js` to display API errors in a toast notification.
- Modifies the `confirmDelete` function to use this error handler, ensuring the user receives feedback when a deletion fails.
- Also adds a toast notification for the Excel export action to improve user feedback.