### PR TITLE
fix(supply): Correct plan editing and deletion errors

### DIFF
--- a/app/Controllers/Api/SupplyPlanApiController.php
+++ b/app/Controllers/Api/SupplyPlanApiController.php
@@ -61,7 +61,10 @@ class SupplyPlanApiController extends BaseApiController
                 return;
             }
 
-            $this->apiSuccess($plan->toArray());
+            $planData = $plan->toArray();
+            $planData['id'] = $id;
+
+            $this->apiSuccess($planData);
         } catch (Exception $e) {
             $this->handleException($e);
         }

--- a/app/Views/pages/supply/plans/index.php
+++ b/app/Views/pages/supply/plans/index.php
@@ -110,7 +110,7 @@
                 <div id="delete-plan-info"></div>
             </div>
             <div class="modal-footer">
-                <button type="button" class="btn-secondary" data-bs-dismiss="modal">취소</button>
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
                 <button type="button" class="btn btn-danger" id="confirm-delete-plan-btn">삭제</button>
             </div>
         </div>

--- a/public/assets/js/pages/supply-plans-index.js
+++ b/public/assets/js/pages/supply-plans-index.js
@@ -199,6 +199,7 @@ class SupplyPlansIndexPage extends BasePage {
             this.loadPlans();
             this.loadBudgetSummary();
         } catch (error) {
+            this.deletePlanModal.hide();
             this.handleApiError(error);
         } finally {
             this.resetButtonLoading('#confirm-delete-plan-btn', '삭제');
@@ -207,6 +208,7 @@ class SupplyPlansIndexPage extends BasePage {
     }
 
     exportToExcel() {
+        Toast.info('엑셀 다운로드를 시작합니다.');
         window.open(`/api/supply/plans/export-excel/${this.currentYear}`, '_blank');
     }
 
@@ -342,6 +344,12 @@ class SupplyPlansIndexPage extends BasePage {
                 "'": '&#39;'
             }[match];
         });
+    }
+
+    handleApiError(error) {
+        const message = error.message || 'An unexpected error occurred.';
+        Toast.error(message);
+        console.error('API Error:', error);
     }
 }
 


### PR DESCRIPTION
This commit resolves two critical bugs in the supply plans feature:

1.  **Undefined ID on Edit:** Fixes a bug where updating a plan would fail because the plan ID was `undefined`. The backend API at `GET /api/supply/plans/{id}` was not including the `id` in its response. The `show` method in the `SupplyPlanApiController` has been updated to explicitly add the plan `id` to the returned JSON data, ensuring the frontend can construct the correct URL for the `PUT` request.

2.  **Missing Deletion Error Message:** Fixes an issue where no error message was displayed when a user tried to delete a plan with existing dependencies. A local `handleApiError` method has been added to `supply-plans-index.js` to catch and display API errors in a toast notification. The `confirmDelete` function now uses this handler to provide clear feedback to the user on failure.

Additionally, this commit includes minor UI improvements:
- Adds a toast notification for the Excel export action.
- Corrects the styling of the "Cancel" button in the delete modal.