### PR TITLE
Fix: supply/purchases 기능 오류 해결 및 개선

### DIFF
--- a/public/assets/js/pages/supply-purchases-index.js
+++ b/public/assets/js/pages/supply-purchases-index.js
@@ -77,7 +77,7 @@ class SupplyPurchasesIndexPage extends BasePage {
             const queryString = new URLSearchParams(params).toString();
             const result = await this.apiCall(`${this.config.API_URL}?${queryString}`);
 
-            this.dataTable.clear().rows.add(result.data || []).draw();
+            this.dataTable.clear().rows.add(result.data.purchases || []).draw();
         } catch (error) {
             console.error('Error loading purchases:', error);
             Toast.error('구매 내역을 불러오는 중 오류가 발생했습니다.');

--- a/routes/api.php
+++ b/routes/api.php
@@ -273,6 +273,7 @@ $router->post('/littering_admin/reports/{id}/approve', [LitteringAdminApiControl
     $router->put('/supply/purchases/{id}', [SupplyPurchaseApiController::class, 'update'])->name('api.supply.purchases.update')->middleware('auth')->middleware('permission', 'supply.purchase.manage');
     $router->delete('/supply/purchases/{id}', [SupplyPurchaseApiController::class, 'destroy'])->name('api.supply.purchases.destroy')->middleware('auth')->middleware('permission', 'supply.purchase.manage');
     $router->post('/supply/purchases/{id}/mark-received', [SupplyPurchaseApiController::class, 'markReceived'])->name('api.supply.purchases.mark-received')->middleware('auth')->middleware('permission', 'supply.purchase.manage');
+    $router->post('/supply/purchases/bulk-receive', [SupplyPurchaseApiController::class, 'bulkReceive'])->name('api.supply.purchases.bulk-receive')->middleware('auth')->middleware('permission', 'supply.purchase.manage');
 
     // 지급 관리 API
     $router->get('/supply/distributions/available-items', [SupplyDistributionApiController::class, 'getAvailableItems'])->name('api.supply.distributions.available-items')->middleware('auth')->middleware('permission', 'supply.distribution.view');


### PR DESCRIPTION
이 커밋은 `supply/purchases` 기능과 관련된 여러 문제를 해결합니다.

1.  **`bulk-receive` API 404 오류 해결**: `routes/api.php`에 누락된 `POST /supply/purchases/bulk-receive` 경로를 추가하여 일괄 입고 처리 기능이 정상적으로 동작하도록 수정했습니다.

2.  **구매 목록 미표시 문제 해결**: `supply-purchases-index.js` 파일에서 API 응답 데이터 구조를 잘못 참조하던 문제를 수정했습니다. `result.data` 대신 `result.data.purchases`를 사용하도록 변경하여 구매 목록이 올바르게 표시되도록 했습니다.

3.  **(이전 수정 포함) 구매 등록 Fatal Error 해결**: `SupplyPurchaseService`에서 초기화되지 않은 `stockRepository` 대신 `stockService`를 사용하도록 수정했습니다.

4.  **(이전 수정 포함) `ActivityLogger` 리팩토링**: `supply` 모듈 전체에서 존재하지 않는 로거 메서드 호출을 범용 `log()` 메서드를 사용하도록 수정했습니다.