### PR TITLE
Fix: Implement getStockList and remove safety_stock feature

### DIFF
--- a/app/Repositories/SupplyStockRepository.php
+++ b/app/Repositories/SupplyStockRepository.php
@@ -253,6 +253,50 @@ class SupplyStockRepository
     }
 
     /**
+     * 재고 목록을 필터링하여 조회합니다.
+     */
+    public function getStockList(array $filters = []): array
+    {
+        $queryParts = [
+            'sql' => "SELECT ss.id, si.item_code, si.item_name, COALESCE(sc.category_name, '미분류') as category_name, si.unit, ss.current_stock, ss.last_received_at
+                      FROM supply_stocks ss
+                      JOIN supply_items si ON ss.item_id = si.id
+                      LEFT JOIN supply_categories sc ON si.category_id = sc.id",
+            'params' => [],
+            'where' => []
+        ];
+
+        if (!empty($filters['category_id'])) {
+            $queryParts['where'][] = "si.category_id = :category_id";
+            $queryParts['params'][':category_id'] = $filters['category_id'];
+        }
+
+        if (!empty($filters['stock_status'])) {
+            switch ($filters['stock_status']) {
+                case 'in_stock':
+                    $queryParts['where'][] = "ss.current_stock > 0";
+                    break;
+                case 'out_of_stock':
+                    $queryParts['where'][] = "ss.current_stock = 0";
+                    break;
+            }
+        }
+
+        if (!empty($filters['search'])) {
+            $queryParts['where'][] = "(si.item_name LIKE :search OR si.item_code LIKE :search)";
+            $queryParts['params'][':search'] = '%' . $filters['search'] . '%';
+        }
+
+        if (!empty($queryParts['where'])) {
+            $queryParts['sql'] .= " WHERE " . implode(" AND ", $queryParts['where']);
+        }
+
+        $queryParts['sql'] .= " ORDER BY sc.category_name ASC, si.item_name ASC";
+
+        return $this->db->query($queryParts['sql'], $queryParts['params']);
+    }
+
+    /**
      * 품목별 재고 초기화를 합니다.
      */
     public function initializeStock(int $itemId): bool

--- a/app/Services/SupplyStockService.php
+++ b/app/Services/SupplyStockService.php
@@ -219,6 +219,14 @@ class SupplyStockService
     }
 
     /**
+     * 재고 목록을 조회합니다.
+     */
+    public function getStockList(array $filters = []): array
+    {
+        return $this->stockRepository->getStockList($filters);
+    }
+
+    /**
      * 품목별 재고를 초기화합니다.
      */
     public function initializeStock(int $itemId): bool

--- a/public/assets/js/pages/supply-stocks.js
+++ b/public/assets/js/pages/supply-stocks.js
@@ -80,25 +80,6 @@ class SupplyStocksPage extends BasePage {
                     data: 'current_stock',
                     render: (data) => data ? parseInt(data).toLocaleString() : '0'
                 },
-                { 
-                    data: 'safety_stock',
-                    render: (data) => data ? parseInt(data).toLocaleString() : '0'
-                },
-                { 
-                    data: 'stock_status',
-                    render: (data, type, row) => {
-                        const current = parseInt(row.current_stock) || 0;
-                        const safety = parseInt(row.safety_stock) || 0;
-                        
-                        if (current === 0) {
-                            return '<span class="badge bg-danger">품절</span>';
-                        } else if (current < safety) {
-                            return '<span class="badge bg-warning">부족</span>';
-                        } else {
-                            return '<span class="badge bg-success">충분</span>';
-                        }
-                    }
-                },
                 { data: 'last_received_at' },
                 {
                     data: null,


### PR DESCRIPTION
This commit resolves a fatal error caused by a call to the undefined method `getStockList` in `SupplyStockApiController`.

It also removes the unimplemented "safety stock" feature, which was causing a secondary SQL error due to a missing database column.

- Added the `getStockList` method to `SupplyStockService` and `SupplyStockRepository` to fix the initial fatal error.
- Updated the SQL query in the repository to remove the non-existent `safety_stock` column.
- Removed the "Safety Stock" and "Stock Status" columns from the frontend datatable in `supply-stocks.js` to align with the backend changes.
- Addressed the "undefined(undefined)" category UI bug by using `COALESCE` in the SQL query.