### PR TITLE
Fix: Implement getStockList and remove unimplemented features

### DIFF
--- a/app/Services/SupplyStockService.php
+++ b/app/Services/SupplyStockService.php
@@ -219,6 +219,14 @@ class SupplyStockService
     }
 
     /**
+     * 재고 목록을 조회합니다.
+     */
+    public function getStockList(array $filters = []): array
+    {
+        return $this->stockRepository->getStockList($filters);
+    }
+
+    /**
      * 품목별 재고를 초기화합니다.
      */
     public function initializeStock(int $itemId): bool

--- a/public/assets/js/pages/supply-stocks.js
+++ b/public/assets/js/pages/supply-stocks.js
@@ -80,26 +80,6 @@ class SupplyStocksPage extends BasePage {
                     data: 'current_stock',
                     render: (data) => data ? parseInt(data).toLocaleString() : '0'
                 },
-                { 
-                    data: 'safety_stock',
-                    render: (data) => data ? parseInt(data).toLocaleString() : '0'
-                },
-                { 
-                    data: 'stock_status',
-                    render: (data, type, row) => {
-                        const current = parseInt(row.current_stock) || 0;
-                        const safety = parseInt(row.safety_stock) || 0;
-                        
-                        if (current === 0) {
-                            return '<span class="badge bg-danger">품절</span>';
-                        } else if (current < safety) {
-                            return '<span class="badge bg-warning">부족</span>';
-                        } else {
-                            return '<span class="badge bg-success">충분</span>';
-                        }
-                    }
-                },
-                { data: 'last_received_at' },
                 {
                     data: null,
                     orderable: false,


### PR DESCRIPTION
This commit resolves a fatal error caused by a call to the undefined method `getStockList` in `SupplyStockApiController`.

It also removes several unimplemented features (`safety_stock`, `last_received_at`) that were causing subsequent SQL errors due to missing database columns.

- Added the `getStockList` method to `SupplyStockService` and `SupplyStockRepository` to fix the initial fatal error.
- Updated the SQL query in the repository to remove the non-existent `safety_stock` and `last_received_at` columns.
- Removed the "Safety Stock," "Stock Status," and "Last Received At" columns from the frontend datatable in `supply-stocks.js` to align with the backend changes.
- Addressed the "undefined(undefined)" category UI bug by using `COALESCE` in the SQL query to provide a default value for null category names.