### PR TITLE
feat: 차량 검사 조회 API 구현 및 UI 헬퍼 적용

### DIFF
--- a/app/Controllers/Api/VehicleInspectionApiController.php
+++ b/app/Controllers/Api/VehicleInspectionApiController.php
@@ -65,6 +65,20 @@ class VehicleInspectionApiController extends BaseApiController
         }
     }
 
+    public function show(int $id): void
+    {
+        try {
+            $inspection = $this->inspectionService->getInspectionById($id);
+            if (!$inspection) {
+                $this->apiNotFound('검사 내역을 찾을 수 없습니다.');
+                return;
+            }
+            $this->apiSuccess($inspection);
+        } catch (Exception $e) {
+            $this->handleException($e);
+        }
+    }
+
     protected function handleException(Exception $e): void
     {
         if ($e instanceof \InvalidArgumentException) {

--- a/app/Repositories/VehicleInspectionRepository.php
+++ b/app/Repositories/VehicleInspectionRepository.php
@@ -65,4 +65,14 @@ class VehicleInspectionRepository
 
         return (int) $this->db->lastInsertId();
     }
+
+    public function findById(int $id): ?VehicleInspection
+    {
+        $sql = "SELECT vi.*, v.vehicle_number, v.model
+                FROM vehicle_inspections vi
+                JOIN vehicles v ON vi.vehicle_id = v.id
+                WHERE vi.id = :id";
+
+        return $this->db->fetchAs(VehicleInspection::class, $sql, [':id' => $id]) ?: null;
+    }
 }

--- a/app/Services/VehicleInspectionService.php
+++ b/app/Services/VehicleInspectionService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Repositories\VehicleInspectionRepository;
+use App\Models\VehicleInspection;
 
 class VehicleInspectionService
 {
@@ -26,5 +27,10 @@ class VehicleInspectionService
     public function getUpcomingInspections(int $days = 30): array
     {
         return $this->inspectionRepository->findAll(['upcoming_expiry' => $days]);
+    }
+
+    public function getInspectionById(int $id): ?VehicleInspection
+    {
+        return $this->inspectionRepository->findById($id);
     }
 }

--- a/public/assets/js/pages/vehicle-inspection.js
+++ b/public/assets/js/pages/vehicle-inspection.js
@@ -29,9 +29,15 @@ class VehicleInspectionPage extends BasePage {
 
         $('#inspectionTable').on('click', '.delete-btn', (e) => {
             const id = $(e.currentTarget).data('id');
-            if (confirm('정말 삭제하시겠습니까?')) {
-                this.deleteInspection(id);
-            }
+            Confirm.fire({
+                title: '삭제 확인',
+                text: '정말 삭제하시겠습니까?',
+                icon: 'warning'
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    this.deleteInspection(id);
+                }
+            });
         });
     }
 
@@ -90,7 +96,7 @@ class VehicleInspectionPage extends BasePage {
             this.dataTable.clear().rows.add(response.data || []).draw();
         } catch (error) {
             console.error('Error loading inspections:', error);
-            alert('데이터를 불러오는 중 오류가 발생했습니다.');
+            Toast.error('데이터를 불러오는 중 오류가 발생했습니다.');
         }
     }
 
@@ -143,7 +149,7 @@ class VehicleInspectionPage extends BasePage {
             new bootstrap.Modal(document.getElementById('addInspectionModal')).show();
         } catch (error) {
             console.error('Error loading inspection details:', error);
-            alert('데이터를 불러오는 중 오류가 발생했습니다.');
+            Toast.error('데이터를 불러오는 중 오류가 발생했습니다.');
         }
     }
 
@@ -159,7 +165,7 @@ class VehicleInspectionPage extends BasePage {
         };
 
         if (!formData.vehicle_id || !formData.inspection_date || !formData.expiry_date || !formData.result) {
-            alert('필수 항목을 모두 입력해주세요.');
+            Toast.warning('필수 항목을 모두 입력해주세요.');
             return;
         }
 
@@ -173,13 +179,13 @@ class VehicleInspectionPage extends BasePage {
                 body: JSON.stringify(formData)
             });
 
-            alert(id ? '수정되었습니다.' : '검사 내역이 등록되었습니다.');
+            Toast.success(id ? '수정되었습니다.' : '검사 내역이 등록되었습니다.');
             bootstrap.Modal.getInstance(document.getElementById('addInspectionModal')).hide();
             document.getElementById('addInspectionForm').reset();
             this.loadInspections();
         } catch (error) {
             console.error('Error saving inspection:', error);
-            alert(error.message || '등록 중 오류가 발생했습니다.');
+            Toast.error(error.message || '등록 중 오류가 발생했습니다.');
         }
     }
 
@@ -188,11 +194,11 @@ class VehicleInspectionPage extends BasePage {
             await this.apiCall(`${this.config.API_URL}/${id}`, {
                 method: 'DELETE'
             });
-            alert('삭제되었습니다.');
+            Toast.success('삭제되었습니다.');
             this.loadInspections();
         } catch (error) {
             console.error('Error deleting inspection:', error);
-            alert('삭제 중 오류가 발생했습니다.');
+            Toast.error('삭제 중 오류가 발생했습니다.');
         }
     }
 }

--- a/tests/VehicleInspectionApiTest.php
+++ b/tests/VehicleInspectionApiTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\TestCase;
+use App\Controllers\Api\VehicleInspectionApiController;
+use App\Services\VehicleInspectionService;
+use App\Models\VehicleInspection;
+use App\Core\Request;
+use App\Core\JsonResponse;
+use App\Services\AuthService;
+use App\Services\ViewDataService;
+use App\Services\ActivityLogger;
+use App\Repositories\EmployeeRepository;
+use Exception;
+
+class VehicleInspectionApiTest extends TestCase
+{
+    private $inspectionService;
+    private $request;
+    private $jsonResponse;
+    private $controller;
+
+    protected function setUp(): void
+    {
+        $this->inspectionService = $this->createMock(VehicleInspectionService::class);
+        $this->request = $this->createMock(Request::class);
+        $this->jsonResponse = $this->createMock(JsonResponse::class);
+
+        // Mock other dependencies that are not directly used in the test
+        $authService = $this->createMock(AuthService::class);
+        $viewDataService = $this->createMock(ViewDataService::class);
+        $activityLogger = $this->createMock(ActivityLogger::class);
+        $employeeRepository = $this->createMock(EmployeeRepository::class);
+
+        $this->controller = new VehicleInspectionApiController(
+            $this->request,
+            $authService,
+            $viewDataService,
+            $activityLogger,
+            $employeeRepository,
+            $this->jsonResponse,
+            $this->inspectionService
+        );
+    }
+
+    public function testShowReturnsInspectionWhenFound()
+    {
+        $inspectionData = new VehicleInspection();
+        $inspectionData->id = 1;
+        $inspectionData->vehicle_id = 1;
+        $inspectionData->inspection_date = '2023-10-01';
+
+        $this->inspectionService->method('getInspectionById')
+            ->with(1)
+            ->willReturn($inspectionData);
+
+        $this->jsonResponse->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function($data) {
+                return $data['status'] === 'success' && $data['data']->id === 1;
+            }));
+
+        $this->controller->show(1);
+    }
+
+    public function testShowReturnsNotFoundWhenInspectionNotFound()
+    {
+        $this->inspectionService->method('getInspectionById')
+            ->with(999)
+            ->willReturn(null);
+
+        $this->jsonResponse->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function($data) {
+                return $data['status'] === 'error' && $data['message'] === '검사 내역을 찾을 수 없습니다.';
+            }), 404);
+
+        $this->controller->show(999);
+    }
+}


### PR DESCRIPTION
- `api/vehicles/inspections/{id}` 404 오류를 해결하기 위해 단일 조회 API 엔드포인트를 구현했습니다.
- Controller, Service, Repository 계층에 `show`, `getInspectionById`, `findById` 메소드를 각각 추가했습니다.
- 신규 API 엔드포인트에 대한 단위 테스트를 추가했습니다.
- `vehicle-inspection.js` 파일의 기존 `alert` 및 `confirm` 호출을 `ui-helpers.js`의 `Toast`와 `Confirm` 모듈을 사용하도록 리팩터링하여 사용자 경험을 개선했습니다.