### PR TITLE
fix(vehicle): resolve multiple vehicle and department API issues

### DIFF
--- a/app/Controllers/Api/VehicleInspectionApiController.php
+++ b/app/Controllers/Api/VehicleInspectionApiController.php
@@ -79,6 +79,27 @@ class VehicleInspectionApiController extends BaseApiController
         }
     }
 
+    public function update(int $id): void
+    {
+        try {
+            $data = $this->request->all();
+            $this->inspectionService->updateInspection($id, $data);
+            $this->apiSuccess(['message' => '검사 내역이 수정되었습니다.']);
+        } catch (Exception $e) {
+            $this->handleException($e);
+        }
+    }
+
+    public function destroy(int $id): void
+    {
+        try {
+            $this->inspectionService->deleteInspection($id);
+            $this->apiSuccess(['message' => '검사 내역이 삭제되었습니다.']);
+        } catch (Exception $e) {
+            $this->handleException($e);
+        }
+    }
+
     protected function handleException(Exception $e): void
     {
         if ($e instanceof \InvalidArgumentException) {

--- a/app/Repositories/VehicleInspectionRepository.php
+++ b/app/Repositories/VehicleInspectionRepository.php
@@ -75,4 +75,31 @@ class VehicleInspectionRepository
 
         return $this->db->fetchOneAs(VehicleInspection::class, $sql, [':id' => $id]) ?: null;
     }
+
+    public function update(int $id, array $data): bool
+    {
+        $fields = [];
+        $params = [':id' => $id];
+
+        foreach ($data as $key => $value) {
+            if (in_array($key, ['vehicle_id', 'inspection_date', 'expiry_date', 'inspector_name', 'result', 'cost', 'document_path'])) {
+                $fields[] = "{$key} = :{$key}";
+                $params[":{$key}"] = $value;
+            }
+        }
+
+        if (empty($fields)) {
+            return false;
+        }
+
+        $sql = "UPDATE vehicle_inspections SET " . implode(', ', $fields) . " WHERE id = :id";
+
+        return $this->db->execute($sql, $params) > 0;
+    }
+
+    public function delete(int $id): bool
+    {
+        $sql = "DELETE FROM vehicle_inspections WHERE id = :id";
+        return $this->db->execute($sql, [':id' => $id]) > 0;
+    }
 }

--- a/app/Services/VehicleInspectionService.php
+++ b/app/Services/VehicleInspectionService.php
@@ -33,4 +33,14 @@ class VehicleInspectionService
     {
         return $this->inspectionRepository->findById($id);
     }
+
+    public function updateInspection(int $id, array $data): void
+    {
+        $this->inspectionRepository->update($id, $data);
+    }
+
+    public function deleteInspection(int $id): void
+    {
+        $this->inspectionRepository->delete($id);
+    }
 }


### PR DESCRIPTION
This commit addresses four separate issues:

1.  **Unassigned Vehicle Visibility**: The `applyVehicleScope` in `DataScopeService` is updated to include vehicles with a NULL `department_id`. This ensures that unassigned vehicles are visible to users with department permissions.

2.  **Fatal Error in Inspection API**: Corrects a typo in `VehicleInspectionRepository` from `fetchAs` to `fetchOneAs`, fixing a fatal error when retrieving a single inspection.

3.  **Department API Formatting**: The `getAll` method in `DepartmentRepository` now casts `Department` objects to arrays. This resolves a data serialization issue that caused the `/api/organization/managable-departments` endpoint to return a malformed empty array.

4.  **API Routing Order**: The order of vehicle-related routes in `routes/api.php` has been corrected. More specific routes like `/vehicles/inspections/{id}` are now defined before the general `/vehicles/{id}` route to prevent conflicts and ensure correct controller dispatch.

5.  **Missing Inspection API Methods**: Implements the `update` and `destroy` methods in the `VehicleInspectionApiController`, `VehicleInspectionService`, and `VehicleInspectionRepository` to support `PUT` and `DELETE` requests for vehicle inspections.